### PR TITLE
Add initial cwbvh node aabb intersection and traversal test.

### DIFF
--- a/examples/demoscene.rs
+++ b/examples/demoscene.rs
@@ -118,7 +118,7 @@ fn main() {
                     let fogc = sky.render(fog_dir).min(Vec3A::splat(100.0));
                     let skyc = sky.render(ray.direction);
                     let sunc = sky.render(-sun_direction);
-                    let mut state = bvh.new_traversal(ray);
+                    let mut state = bvh.new_ray_traversal(ray);
                     while bvh.traverse_dynamic(&mut state, &mut hit, intersection_fn) {}
                     if hit.t < f32::MAX {
                         let mut normal = bvh_tris[hit.primitive_id as usize].compute_normal();

--- a/src/aabb.rs
+++ b/src/aabb.rs
@@ -182,14 +182,14 @@ impl Aabb {
 
     /// Checks if this AABB intersects with another AABB.
     #[inline]
-    pub fn aabb_intersect(&self, other: &Aabb) -> bool {
+    pub fn intersect_aabb(&self, other: &Aabb) -> bool {
         !(self.min.cmpgt(other.max).any() || self.max.cmplt(other.min).any())
     }
 
     /// Checks if this AABB intersects with a ray and returns the distance to the intersection point.
     /// Returns `f32::MAX` if there is no intersection.
     #[inline]
-    pub fn ray_intersect(&self, ray: &Ray) -> f32 {
+    pub fn intersect_ray(&self, ray: &Ray) -> f32 {
         let t1 = (self.min - ray.origin) * ray.inv_direction;
         let t2 = (self.max - ray.origin) * ray.inv_direction;
 
@@ -340,20 +340,20 @@ mod tests {
     }
 
     #[test]
-    fn test_aabb_intersect() {
+    fn test_intersect_aabb() {
         let aabb1 = Aabb::new(Vec3A::ZERO, Vec3A::ONE);
         let aabb2 = Aabb::new(Vec3A::splat(0.5), Vec3A::splat(1.5));
-        assert!(aabb1.aabb_intersect(&aabb2));
+        assert!(aabb1.intersect_aabb(&aabb2));
         let aabb3 = Aabb::new(Vec3A::splat(1.5), Vec3A::splat(2.5));
-        assert!(!aabb1.aabb_intersect(&aabb3));
+        assert!(!aabb1.intersect_aabb(&aabb3));
     }
 
     #[test]
-    fn test_ray_intersect() {
+    fn test_intersect_ray() {
         let aabb = Aabb::new(Vec3A::ZERO, Vec3A::ONE);
         let ray = Ray::new(Vec3A::splat(-1.0), Vec3A::ONE, 0.0, f32::MAX);
-        assert_eq!(aabb.ray_intersect(&ray), 1.0);
+        assert_eq!(aabb.intersect_ray(&ray), 1.0);
         let ray_no_intersect = Ray::new(Vec3A::splat(2.0), Vec3A::ONE, 0.0, f32::MAX);
-        assert_eq!(aabb.ray_intersect(&ray_no_intersect), f32::MAX);
+        assert_eq!(aabb.intersect_ray(&ray_no_intersect), f32::MAX);
     }
 }

--- a/src/bvh2/mod.rs
+++ b/src/bvh2/mod.rs
@@ -271,6 +271,8 @@ impl Bvh2 {
 
     /// Traverse the BVH with an Aabb. fn `eval` is called for nodes that intersect `aabb`
     /// The bvh (self) and the current node index is passed into fn `eval`
+    /// Note each node may have multiple primitives. `node.first_index` is the index of the first primitive.
+    /// `node.prim_count` is the quantity of primitives contained in the given node.
     /// Return false from eval to halt traversal
     pub fn aabb_intersect<F: FnMut(&Self, u32) -> bool>(&self, aabb: Aabb, mut eval: F) {
         let mut stack =

--- a/src/bvh2/mod.rs
+++ b/src/bvh2/mod.rs
@@ -234,7 +234,7 @@ impl Bvh2 {
             }
             if let Some(current_node_index) = state.stack.pop() {
                 let node = &self.nodes[*current_node_index as usize];
-                if node.aabb.ray_intersect(&state.ray) >= state.ray.tmax {
+                if node.aabb.intersect_ray(&state.ray) >= state.ray.tmax {
                     continue;
                 }
 
@@ -263,7 +263,7 @@ impl Bvh2 {
         if node.is_leaf() {
             let primitive_id = node.first_index as usize;
             indices.push(primitive_id);
-        } else if node.aabb.ray_intersect(ray) < f32::MAX {
+        } else if node.aabb.intersect_ray(ray) < f32::MAX {
             self.traverse_recursive(ray, node.first_index as usize, indices);
             self.traverse_recursive(ray, node.first_index as usize + 1, indices);
         }
@@ -274,13 +274,13 @@ impl Bvh2 {
     /// Note each node may have multiple primitives. `node.first_index` is the index of the first primitive.
     /// `node.prim_count` is the quantity of primitives contained in the given node.
     /// Return false from eval to halt traversal
-    pub fn aabb_intersect<F: FnMut(&Self, u32) -> bool>(&self, aabb: Aabb, mut eval: F) {
+    pub fn intersect_aabb<F: FnMut(&Self, u32) -> bool>(&self, aabb: Aabb, mut eval: F) {
         let mut stack =
             HeapStack::new_with_capacity(self.max_depth.unwrap_or(DEFAULT_MAX_STACK_DEPTH));
         stack.push(0);
         while let Some(current_node_index) = stack.pop() {
             let node = &self.nodes[*current_node_index as usize];
-            if !node.aabb.aabb_intersect(&aabb) {
+            if !node.aabb.intersect_aabb(&aabb) {
                 continue;
             }
 

--- a/src/cwbvh/mod.rs
+++ b/src/cwbvh/mod.rs
@@ -195,7 +195,7 @@ impl CwBvh {
             self,
             node,
             state,
-            CwBvhNode::intersect_ray(node, &traverse_ray, state.oct_inv4),
+            node.intersect_ray(&traverse_ray, state.oct_inv4),
             {
                 let t = intersection_fn(&traverse_ray, state.primitive_id as usize);
                 if t < traverse_ray.tmax {

--- a/src/cwbvh/node.rs
+++ b/src/cwbvh/node.rs
@@ -153,7 +153,7 @@ impl CwBvhNode {
                     ),
                 );
 
-                if child_aabb.aabb_intersect(&adjusted_aabb) {
+                if child_aabb.intersect_aabb(&adjusted_aabb) {
                     let child_bits = extract_byte(child_bits4, j as u32);
                     let bit_index = extract_byte(bit_index4, j as u32);
 

--- a/src/cwbvh/node.rs
+++ b/src/cwbvh/node.rs
@@ -1,0 +1,184 @@
+use bytemuck::{Pod, Zeroable};
+use glam::{vec3a, Vec3, Vec3A};
+
+use crate::{aabb::Aabb, ray::Ray};
+
+/// A Compressed Wide BVH8 Node
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[repr(C)]
+pub struct CwBvhNode {
+    /// Min point
+    pub p: Vec3,
+    /// Exponent of child bounding box compression
+    pub e: [u8; 3],
+    /// Indicates which children are internal nodes
+    pub imask: u8,
+    pub child_base_idx: u32,
+    pub primitive_base_idx: u32,
+    pub child_meta: [u8; 8],
+
+    // Note: deviation from the paper: the min&max are interleaved here.
+    pub child_min_x: [u8; 8],
+    pub child_max_x: [u8; 8],
+    pub child_min_y: [u8; 8],
+    pub child_max_y: [u8; 8],
+    pub child_min_z: [u8; 8],
+    pub child_max_z: [u8; 8],
+}
+
+pub(crate) const EPSILON: f32 = 0.0001;
+unsafe impl Pod for CwBvhNode {}
+unsafe impl Zeroable for CwBvhNode {}
+
+impl CwBvhNode {
+    #[inline(always)]
+    pub fn intersect_ray(&self, ray: &Ray, oct_inv4: u32) -> u32 {
+        #[cfg(all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            target_feature = "sse2"
+        ))]
+        {
+            self.intersect_ray_simd(ray, oct_inv4)
+        }
+
+        #[cfg(not(all(
+            any(target_arch = "x86", target_arch = "x86_64"),
+            target_feature = "sse2"
+        )))]
+        {
+            self.intersect_basic(ray, oct_inv4)
+        }
+    }
+
+    /// Intersects only one child at a time with the given ray. Limited simd usage on platforms that support it. Exists for reference & compatibility.
+    #[inline(always)]
+    pub fn intersect_ray_basic(&self, ray: &Ray, oct_inv4: u32) -> u32 {
+        let adjusted_ray_dir_inv = vec3a(
+            f32::from_bits((self.e[0] as u32) << 23),
+            f32::from_bits((self.e[1] as u32) << 23),
+            f32::from_bits((self.e[2] as u32) << 23),
+        ) * ray.inv_direction;
+        let adjusted_ray_origin = (Vec3A::from(self.p) - ray.origin) * ray.inv_direction;
+
+        let mut hit_mask = 0;
+
+        let rdx = ray.direction.x < 0.0;
+        let rdy = ray.direction.y < 0.0;
+        let rdz = ray.direction.z < 0.0;
+
+        // [unroll]
+        for i in 0..2 {
+            let meta4 = extract_u32(&self.child_meta, i == 0);
+            let is_inner4 = (meta4 & (meta4 << 1)) & 0x10101010;
+            let inner_mask4 = (is_inner4 >> 4) * 0xffu32;
+            let bit_index4 = (meta4 ^ (oct_inv4 & inner_mask4)) & 0x1f1f1f1f;
+            let child_bits4 = (meta4 >> 5) & 0x07070707;
+
+            // [unroll]
+            for j in 0..4 {
+                let ch = i * 4 + j;
+
+                let q_lo_x = self.child_min_x[ch];
+                let q_lo_y = self.child_min_y[ch];
+                let q_lo_z = self.child_min_z[ch];
+
+                let q_hi_x = self.child_max_x[ch];
+                let q_hi_y = self.child_max_y[ch];
+                let q_hi_z = self.child_max_z[ch];
+
+                let x_min = if rdx { q_hi_x } else { q_lo_x };
+                let x_max = if rdx { q_lo_x } else { q_hi_x };
+                let y_min = if rdy { q_hi_y } else { q_lo_y };
+                let y_max = if rdy { q_lo_y } else { q_hi_y };
+                let z_min = if rdz { q_hi_z } else { q_lo_z };
+                let z_max = if rdz { q_lo_z } else { q_hi_z };
+
+                let mut tmin3 = vec3a(x_min as f32, y_min as f32, z_min as f32);
+                let mut tmax3 = vec3a(x_max as f32, y_max as f32, z_max as f32);
+
+                // Account for grid origin and scale
+                tmin3 = tmin3 * adjusted_ray_dir_inv + adjusted_ray_origin;
+                tmax3 = tmax3 * adjusted_ray_dir_inv + adjusted_ray_origin;
+
+                let tmin = tmin3.x.max(tmin3.y).max(tmin3.z).max(EPSILON); //ray.tmin?
+                let tmax = tmax3.x.min(tmax3.y).min(tmax3.z).min(ray.tmax);
+
+                let intersected = tmin <= tmax;
+                if intersected {
+                    let child_bits = extract_byte(child_bits4, j as u32);
+                    let bit_index = extract_byte(bit_index4, j as u32);
+
+                    hit_mask |= child_bits << bit_index;
+                }
+            }
+        }
+
+        hit_mask
+    }
+
+    #[inline(always)]
+    pub fn intersect_aabb(&self, aabb: &Aabb, oct_inv4: u32) -> u32 {
+        let extent = vec3a(
+            f32::from_bits((self.e[0] as u32) << 23),
+            f32::from_bits((self.e[1] as u32) << 23),
+            f32::from_bits((self.e[2] as u32) << 23),
+        );
+        let extent_rcp = 1.0 / extent;
+        let p = Vec3A::from(self.p);
+
+        // Transform the query aabb into the node's local space
+        let adjusted_aabb = Aabb::new((aabb.min - p) * extent_rcp, (aabb.max - p) * extent_rcp);
+
+        let mut hit_mask = 0;
+
+        for i in 0..2 {
+            let meta4 = extract_u32(&self.child_meta, i == 0);
+            let is_inner4 = (meta4 & (meta4 << 1)) & 0x10101010;
+            let inner_mask4 = (is_inner4 >> 4) * 0xffu32;
+            let bit_index4 = (meta4 ^ (oct_inv4 & inner_mask4)) & 0x1f1f1f1f;
+            let child_bits4 = (meta4 >> 5) & 0x07070707;
+
+            for j in 0..4 {
+                let ch = i * 4 + j;
+                let child_aabb = Aabb::new(
+                    vec3a(
+                        self.child_min_x[ch] as f32,
+                        self.child_min_y[ch] as f32,
+                        self.child_min_z[ch] as f32,
+                    ),
+                    vec3a(
+                        self.child_max_x[ch] as f32,
+                        self.child_max_y[ch] as f32,
+                        self.child_max_z[ch] as f32,
+                    ),
+                );
+
+                if child_aabb.aabb_intersect(&adjusted_aabb) {
+                    let child_bits = extract_byte(child_bits4, j as u32);
+                    let bit_index = extract_byte(bit_index4, j as u32);
+
+                    hit_mask |= child_bits << bit_index;
+                }
+            }
+        }
+
+        hit_mask
+    }
+}
+
+#[inline(always)]
+#[allow(dead_code)]
+pub fn extract_byte(x: u32, b: u32) -> u32 {
+    (x >> (b * 8)) & 0xFFu32
+}
+
+#[inline(always)]
+#[allow(dead_code)]
+pub fn extract_byte64(x: u64, b: usize) -> u32 {
+    ((x >> (b * 8)) as u32) & 0xFFu32
+}
+
+#[inline(always)]
+pub fn extract_u32(data: &[u8; 8], second: bool) -> u32 {
+    unsafe { *(data.as_ptr().add(if second { 0 } else { 4 }) as *const u32) }
+}

--- a/src/cwbvh/simd.rs
+++ b/src/cwbvh/simd.rs
@@ -5,12 +5,14 @@ use std::arch::x86::*;
 use std::arch::x86_64::*;
 use std::mem::transmute;
 
-use crate::{cwbvh::CwBvhNode, ray::Ray};
-const EPSILON: f32 = 0.0001;
+use crate::{
+    cwbvh::{node::EPSILON, CwBvhNode},
+    ray::Ray,
+};
 
 impl CwBvhNode {
     #[inline(always)]
-    pub fn intersect_simd(&self, ray: &Ray, oct_inv4: u32) -> u32 {
+    pub fn intersect_ray_simd(&self, ray: &Ray, oct_inv4: u32) -> u32 {
         let adj_ray_dir_inv = vec3a(
             f32::from_bits((self.e[0] as u32) << 23),
             f32::from_bits((self.e[1] as u32) << 23),

--- a/src/cwbvh/traverse_macro.rs
+++ b/src/cwbvh/traverse_macro.rs
@@ -3,7 +3,7 @@
 /// both generic node and primitive traversal.
 ///
 /// # Parameters
-/// - `$cwbvh`: `&CwBvh` The complete bounding volume hierarchy to traverse.
+/// - `$cwbvh`: `&CwBvh` The CWBVH to be traversed.
 /// - `$node`: `&CwBvhNode` The current node in the BVH that is being traversed.
 /// - `$state`: `Traversal` Mutable traversal state.
 /// - `$node_intersection`: An expression that is executed for each node intersection during traversal.
@@ -38,7 +38,7 @@
 /// let mut node;
 /// traverse!(bvh, node, state,
 ///     // Node intersection:
-///     CwBvhNode::intersect_ray(node, &traverse_ray, state.oct_inv4),
+///     node.intersect_ray(&traverse_ray, state.oct_inv4),
 ///     // Primitive intersection:
 ///     {
 ///         let t = tris[bvh.primitive_indices[state.primitive_id as usize] as usize].intersect(&traverse_ray);

--- a/src/cwbvh/traverse_macro.rs
+++ b/src/cwbvh/traverse_macro.rs
@@ -1,0 +1,119 @@
+/// Traverse the BVH with custom node and primitive intersections.
+/// I really didn't want to use a macro but it seems like everything else using closures/yielding is slower given
+/// both generic node and primitive traversal.
+///
+/// # Parameters
+/// - `$cwbvh`: `&CwBvh` The complete bounding volume hierarchy to traverse.
+/// - `$node`: `&CwBvhNode` The current node in the BVH that is being traversed.
+/// - `$state`: `Traversal` Mutable traversal state.
+/// - `$node_intersection`: An expression that is executed for each node intersection during traversal.
+///     It should test for intersection against the current `node`, making use of `state.oct_inv4` u32.
+///     It should return a u32 `hitmask` of the node children hitmask corresponding to which nodes were intersected.
+/// - `$primitive_intersection`: A code block that is executed for each primitive intersection.
+///     It should read the current `state.primitive_id` u32. This is the index into the primitive indices for the
+///     current primitive to be tested. Optionally use `break` to halt traversal.
+///
+/// # Example: Closest hit ray traversal
+/// ```
+/// use obvhs::{
+///     cwbvh::{builder::build_cwbvh_from_tris, node::CwBvhNode},
+///     ray::{Ray, RayHit},
+///     test_util::geometry::{icosphere, PLANE},
+///     triangle::Triangle,
+///     BvhBuildParams,
+///     traverse,
+/// };
+/// use glam::*;
+///
+/// let mut tris: Vec<Triangle> = Vec::new();
+/// tris.extend(icosphere(1));
+/// tris.extend(PLANE);
+///
+/// let ray = Ray::new_inf(vec3a(0.1, 0.1, 4.0), vec3a(0.0, 0.0, -1.0));
+///
+/// let bvh = build_cwbvh_from_tris(&tris, BvhBuildParams::medium_build(), &mut 0.0);
+/// let mut hit = RayHit::none();
+/// let mut traverse_ray = ray.clone();
+/// let mut state = bvh.new_traversal(ray.direction);
+/// let mut node;
+/// traverse!(bvh, node, state,
+///     // Node intersection:
+///     CwBvhNode::intersect_ray(node, &traverse_ray, state.oct_inv4),
+///     // Primitive intersection:
+///     {
+///         let t = tris[bvh.primitive_indices[state.primitive_id as usize] as usize].intersect(&traverse_ray);
+///         if t < traverse_ray.tmax {
+///             hit.primitive_id = state.primitive_id;
+///             hit.t = t;
+///             traverse_ray.tmax = t;
+///         }
+///     }
+/// );
+///
+/// let did_hit = hit.t < ray.tmax;
+/// assert!(did_hit);
+/// assert!(bvh.primitive_indices[hit.primitive_id as usize] == 62);
+/// ```
+#[macro_export]
+macro_rules! traverse {
+    ($cwbvh:expr, $node:expr, $state:expr, $node_intersection:expr, $primitive_intersection:expr) => {{
+        loop {
+            // While the primitive group is not empty
+            while $state.primitive_group.y != 0 {
+                let local_primitive_index = $crate::cwbvh::firstbithigh($state.primitive_group.y);
+
+                // Remove primitive from current_group
+                $state.primitive_group.y &= !(1u32 << local_primitive_index);
+
+                $state.primitive_id = $state.primitive_group.x + local_primitive_index;
+                $primitive_intersection
+            }
+            $state.primitive_group = UVec2::ZERO;
+
+            // If there's remaining nodes in the current group to check
+            if $state.current_group.y & 0xff000000 != 0 {
+                let hits_imask = $state.current_group.y;
+
+                let child_index_offset = $crate::cwbvh::firstbithigh(hits_imask);
+                let child_index_base = $state.current_group.x;
+
+                // Remove node from current_group
+                $state.current_group.y &= !(1u32 << child_index_offset);
+
+                // If the node group is not yet empty, push it on the stack
+                if $state.current_group.y & 0xff000000 != 0 {
+                    $state.stack.push($state.current_group);
+                }
+
+                let slot_index = (child_index_offset - 24) ^ ($state.oct_inv4 & 0xff);
+                let relative_index = (hits_imask & !(0xffffffffu32 << slot_index)).count_ones();
+
+                let child_node_index = child_index_base + relative_index;
+
+                $node = &$cwbvh.nodes[child_node_index as usize];
+
+                $state.hitmask = $node_intersection;
+
+                $state.current_group.x = $node.child_base_idx;
+                $state.primitive_group.x = $node.primitive_base_idx;
+
+                $state.current_group.y = (&$state.hitmask & 0xff000000u32) | ($node.imask as u32);
+                $state.primitive_group.y = &$state.hitmask & 0x00ffffffu32;
+            } else {
+                $state.primitive_group = $state.current_group;
+                $state.current_group = UVec2::ZERO;
+            }
+
+            // If there's no remaining nodes in the current group to check, pop it off the stack.
+            if $state.primitive_group.y == 0 && ($state.current_group.y & 0xff000000) == 0 {
+                // If the stack is empty, end traversal.
+                if $state.stack.is_empty() {
+                    $state.current_group.y = 0;
+                    break;
+                }
+
+                $state.current_group = $state.stack.pop_fast();
+            }
+        }
+    }};
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -7,7 +7,7 @@ mod tests {
         bvh2::builder::{build_bvh2, build_bvh2_from_tris},
         cwbvh::{
             builder::{build_cwbvh, build_cwbvh_from_tris},
-            CwBvhNode, TraversalStack32,
+            CwBvhNode, Traversal,
         },
         ray::{Ray, RayHit},
         test_util::geometry::{demoscene, height_to_triangles},
@@ -154,23 +154,26 @@ mod tests {
         let mut cw_intersect_count = 0;
         let mut cw_intersect_sum = 0usize;
         cwbvh.validate(false, false, &tris);
-        let mut stack = TraversalStack32::default();
-        cwbvh.traverse_fn(
-            &mut stack,
-            &Vec3A::ZERO,
-            |node, _, oct_inv4| CwBvhNode::intersect_aabb(&node, &aabb, oct_inv4),
-            {
-                |id| {
-                    let primitive_id = cwbvh.primitive_indices[id] as usize;
-                    let tri = tris[primitive_id];
-                    if aabb.aabb_intersect(&tri.aabb()) {
-                        cw_intersect_count += 1;
-                        cw_intersect_sum = cw_intersect_sum.wrapping_add(primitive_id);
-                    }
-                    true
-                }
-            },
-        );
+
+        let mut state = Traversal::default();
+        state.reinit(Vec3A::ZERO);
+
+        loop {
+            let primitive_id = cwbvh.traverse_fn(&mut state, |node, _, oct_inv4| {
+                CwBvhNode::intersect_aabb(&node, &aabb, oct_inv4)
+            });
+            if primitive_id == u32::MAX {
+                break;
+            }
+
+            let primitive_id = cwbvh.primitive_indices[primitive_id as usize] as usize;
+            let tri = tris[primitive_id];
+            if aabb.aabb_intersect(&tri.aabb()) {
+                cw_intersect_count += 1;
+                cw_intersect_sum = cw_intersect_sum.wrapping_add(primitive_id);
+            }
+        }
+
         assert_eq!(refrence_count, cw_intersect_count);
         assert_eq!(refrence_intersect_sum, cw_intersect_sum);
     }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -7,7 +7,7 @@ mod tests {
         bvh2::builder::{build_bvh2, build_bvh2_from_tris},
         cwbvh::{
             builder::{build_cwbvh, build_cwbvh_from_tris},
-            CwBvhNode,
+            node::CwBvhNode,
         },
         ray::{Ray, RayHit},
         test_util::geometry::{demoscene, height_to_triangles},

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -162,9 +162,7 @@ mod tests {
             cwbvh,
             node,
             state,
-            {
-                state.hitmask = CwBvhNode::intersect_aabb(&node, &aabb, state.oct_inv4);
-            },
+            CwBvhNode::intersect_aabb(&node, &aabb, state.oct_inv4),
             {
                 let primitive_id = cwbvh.primitive_indices[state.primitive_id as usize] as usize;
                 let tri = tris[primitive_id];

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,12 +1,13 @@
 #[cfg(test)]
 mod tests {
+
     use glam::*;
     use obvhs::{
         aabb::Aabb,
-        bvh2::builder::build_bvh2,
+        bvh2::builder::{build_bvh2, build_bvh2_from_tris},
         cwbvh::builder::{build_cwbvh, build_cwbvh_from_tris},
         ray::{Ray, RayHit},
-        test_util::geometry::height_to_triangles,
+        test_util::geometry::{demoscene, height_to_triangles},
         triangle::Triangle,
         BvhBuildParams,
     };
@@ -109,5 +110,58 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    pub fn traverse_aabb() {
+        let tris = demoscene(201, 0);
+        let aabb = Aabb::new(vec3a(0.511, -1.0, 0.511), vec3a(0.611, 1.0, 0.611));
+
+        let mut refrence_intersect_sum = 0usize;
+        let mut refrence_count = 0;
+        for (id, tri) in tris.iter().enumerate() {
+            if aabb.aabb_intersect(&tri.aabb()) {
+                refrence_intersect_sum = refrence_intersect_sum.wrapping_add(id);
+                refrence_count += 1;
+            }
+        }
+
+        // BVH2
+        let bvh2 = build_bvh2_from_tris(&tris, BvhBuildParams::fast_build(), &mut 0.0);
+        let mut intersect_sum = 0usize;
+        let mut intersect_count = 0;
+        bvh2.validate(&tris, false, false);
+        bvh2.aabb_intersect(aabb, |bvh, id| {
+            let node = &bvh.nodes[id as usize];
+            for i in 0..node.prim_count {
+                let primitive_id = bvh.primitive_indices[(node.first_index + i) as usize] as usize;
+                let tri = tris[primitive_id];
+                if aabb.aabb_intersect(&tri.aabb()) {
+                    intersect_count += 1;
+                    intersect_sum = intersect_sum.wrapping_add(primitive_id);
+                }
+            }
+            true
+        });
+        assert_eq!(refrence_count, intersect_count);
+        assert_eq!(refrence_intersect_sum, intersect_sum);
+
+        // CWBVH
+        let cwbvh = build_cwbvh_from_tris(&tris, BvhBuildParams::fast_build(), &mut 0.0);
+        let mut traversal = cwbvh.new_traversal(Ray::new_inf(Vec3A::ZERO, Vec3A::ONE));
+        let mut cw_intersect_count = 0;
+        let mut cw_intersect_sum = 0usize;
+        cwbvh.validate(false, false, &tris);
+        cwbvh.traverse_aabb(&mut traversal, &aabb, |id| {
+            let primitive_id = cwbvh.primitive_indices[id] as usize;
+            let tri = tris[primitive_id];
+            if aabb.aabb_intersect(&tri.aabb()) {
+                cw_intersect_count += 1;
+                cw_intersect_sum = cw_intersect_sum.wrapping_add(primitive_id);
+            }
+            true
+        });
+        assert_eq!(refrence_count, cw_intersect_count);
+        assert_eq!(refrence_intersect_sum, cw_intersect_sum);
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -5,10 +5,7 @@ mod tests {
     use obvhs::{
         aabb::Aabb,
         bvh2::builder::{build_bvh2, build_bvh2_from_tris},
-        cwbvh::{
-            builder::{build_cwbvh, build_cwbvh_from_tris},
-            node::CwBvhNode,
-        },
+        cwbvh::builder::{build_cwbvh, build_cwbvh_from_tris},
         ray::{Ray, RayHit},
         test_util::geometry::{demoscene, height_to_triangles},
         traverse,
@@ -162,7 +159,7 @@ mod tests {
             cwbvh,
             node,
             state,
-            CwBvhNode::intersect_aabb(&node, &aabb, state.oct_inv4),
+            node.intersect_aabb(&aabb, state.oct_inv4),
             {
                 let primitive_id = cwbvh.primitive_indices[state.primitive_id as usize] as usize;
                 let tri = tris[primitive_id];

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -124,7 +124,7 @@ mod tests {
         let mut refrence_intersect_sum = 0usize;
         let mut refrence_count = 0;
         for (id, tri) in tris.iter().enumerate() {
-            if aabb.aabb_intersect(&tri.aabb()) {
+            if aabb.intersect_aabb(&tri.aabb()) {
                 refrence_intersect_sum = refrence_intersect_sum.wrapping_add(id);
                 refrence_count += 1;
             }
@@ -135,12 +135,12 @@ mod tests {
         let mut intersect_sum = 0usize;
         let mut intersect_count = 0;
         bvh2.validate(&tris, false, false);
-        bvh2.aabb_intersect(aabb, |bvh, id| {
+        bvh2.intersect_aabb(aabb, |bvh, id| {
             let node = &bvh.nodes[id as usize];
             for i in 0..node.prim_count {
                 let primitive_id = bvh.primitive_indices[(node.first_index + i) as usize] as usize;
                 let tri = tris[primitive_id];
-                if aabb.aabb_intersect(&tri.aabb()) {
+                if aabb.intersect_aabb(&tri.aabb()) {
                     intersect_count += 1;
                     intersect_sum = intersect_sum.wrapping_add(primitive_id);
                 }
@@ -166,7 +166,7 @@ mod tests {
             {
                 let primitive_id = cwbvh.primitive_indices[state.primitive_id as usize] as usize;
                 let tri = tris[primitive_id];
-                if aabb.aabb_intersect(&tri.aabb()) {
+                if aabb.intersect_aabb(&tri.aabb()) {
                     cw_intersect_count += 1;
                     cw_intersect_sum = cw_intersect_sum.wrapping_add(primitive_id);
                 }


### PR DESCRIPTION
Also adds a `traverse!` macro for traversal with user defined intersection tests for both nodes and primitives.

I really didn't want to use a macro but it seems like everything else using closures/yielding is slower given both generic node and primitive traversal.

Also makes some naming conventions a bit more consistent (`intersect_aabb` vs `aabb_intersect`, etc...)

Using the traversal macro in `CwBvh::traverse()` seems to yield a slight performance improvement.