### PR TITLE
Bumped glam version to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bvh", "sah", "aabb", "cwbvh", "ploc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-glam = { version = "0.27", features = ["bytemuck"] }
+glam = { version = "0.29", features = ["bytemuck"] }
 half = "2.3.1"
 bytemuck = "1.15"
 rdst = { version = "0.20.14", default-features = false }


### PR DESCRIPTION
Updated the glam version to work with the recent bevy 0.15 release.