### PR TITLE
Init bvh max depth during ploc building

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ half = "2.3.1"
 bytemuck = "1.15"
 rdst = { version = "0.20.14", default-features = false }
 rayon = { version = "1.9.0", optional = true }
+log = "0.4"
 
 # Noop unless one of the profile-with features below is also used
 profiling = { version = "1.0", optional = true }

--- a/src/bvh2/mod.rs
+++ b/src/bvh2/mod.rs
@@ -436,6 +436,9 @@ impl Bvh2 {
             result.max_depth,
             self.max_depth as u32
         );
+        if result.max_depth > DEFAULT_MAX_STACK_DEPTH as u32 {
+            log::warn!("bvh depth is: {}, a depth beyond {} may be indicative of something pathological in the scene (like thousands of instances perfectly overlapping geometry) that will result in a BVH that is very slow to traverse.", result.max_depth, DEFAULT_MAX_STACK_DEPTH);
+        }
 
         result
     }

--- a/src/bvh2/mod.rs
+++ b/src/bvh2/mod.rs
@@ -430,7 +430,12 @@ impl Bvh2 {
             self.primitive_indices.len()
         );
         assert_eq!(result.prim_count, self.primitive_indices.len());
-        assert!(result.max_depth < self.max_depth as u32);
+        assert!(
+            result.max_depth < self.max_depth as u32,
+            "result.max_depth ({}) must be less than self.max_depth ({})",
+            result.max_depth,
+            self.max_depth as u32
+        );
 
         result
     }

--- a/src/ploc/mod.rs
+++ b/src/ploc/mod.rs
@@ -245,7 +245,7 @@ pub fn build_ploc_from_leafs<const SEARCH_DISTANCE: usize>(
 
     insert_index = insert_index.saturating_sub(1);
     bvh.nodes[insert_index] = current_nodes[0];
-    bvh.max_depth = DEFAULT_MAX_STACK_DEPTH.max(depth);
+    bvh.max_depth = DEFAULT_MAX_STACK_DEPTH.max(depth + 1);
 }
 
 #[cfg(feature = "parallel")]

--- a/src/ploc/mod.rs
+++ b/src/ploc/mod.rs
@@ -16,6 +16,7 @@ use rayon::iter::{
     IntoParallelRefMutIterator, ParallelIterator,
 };
 
+use crate::bvh2::DEFAULT_MAX_STACK_DEPTH;
 use crate::ploc::morton::{morton_encode_u128_unorm, morton_encode_u64_unorm};
 use crate::{
     aabb::Aabb,
@@ -103,26 +104,30 @@ pub fn build_ploc<const SEARCH_DISTANCE: usize>(
         });
     }
 
-    let nodes = build_ploc_from_leafs::<SEARCH_DISTANCE>(
+    // TODO make it possible to reuse the allocations from an existing Bvh2 to build a new one
+    let mut bvh = Bvh2 {
+        primitive_indices: indices,
+        ..Default::default()
+    };
+
+    build_ploc_from_leafs::<SEARCH_DISTANCE>(
+        &mut bvh,
         init_leafs,
         total_aabb,
         sort_precision,
         search_depth_threshold,
     );
 
-    Bvh2 {
-        nodes,
-        primitive_indices: indices,
-        ..Default::default()
-    }
+    bvh
 }
 
 pub fn build_ploc_from_leafs<const SEARCH_DISTANCE: usize>(
+    bvh: &mut Bvh2,
     mut current_nodes: Vec<Bvh2Node>,
     total_aabb: Aabb,
     sort_precision: SortPrecision,
     search_depth_threshold: usize,
-) -> Vec<Bvh2Node> {
+) {
     crate::scope!("build_ploc_from_leafs");
 
     let prim_count = current_nodes.len();
@@ -136,7 +141,8 @@ pub fn build_ploc_from_leafs<const SEARCH_DISTANCE: usize>(
     // Sort primitives according to their morton code
     sort_precision.sort_nodes(&mut current_nodes, scale, offset);
 
-    let mut nodes = vec![Bvh2Node::default(); nodes_count];
+    bvh.nodes.clear();
+    bvh.nodes.resize(nodes_count, Bvh2Node::default());
 
     let mut insert_index = nodes_count;
     let mut next_nodes = Vec::with_capacity(prim_count);
@@ -217,8 +223,8 @@ pub fn build_ploc_from_leafs<const SEARCH_DISTANCE: usize>(
             });
 
             // Out of bounds here error here could indicate NaN present in input aabb. Try running in debug mode.
-            nodes[insert_index] = left;
-            nodes[insert_index + 1] = right;
+            bvh.nodes[insert_index] = left;
+            bvh.nodes[insert_index + 1] = right;
 
             if SEARCH_DISTANCE == 1 && index_offset == 1 {
                 // If the search distance is only 1, and the next index was merged with this one,
@@ -238,8 +244,8 @@ pub fn build_ploc_from_leafs<const SEARCH_DISTANCE: usize>(
     }
 
     insert_index = insert_index.saturating_sub(1);
-    nodes[insert_index] = current_nodes[0];
-    nodes
+    bvh.nodes[insert_index] = current_nodes[0];
+    bvh.max_depth = DEFAULT_MAX_STACK_DEPTH.max(depth);
 }
 
 #[cfg(feature = "parallel")]


### PR DESCRIPTION
This allows arbitrarily deep BVHs to be easily created. Generally, very deep BVHs are indicative of something pathological in the scene (like thousands of instances perfectly overlapping geometry) that will result in a BVH that is very slow to traverse. (Note this isn't a limitation of OBVHS, many scenes with these kinds of issues will be slow to traverse with any BVH, and would even be slow to rasterize)

Need to consider if OBVHS should `warn!()` or something if it finds an oddly deep BVH.