### PR TITLE
Move to Rust 2024 Edition, Update Dependencies, and Lint Code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ keywords = ["bvh", "sah", "aabb", "cwbvh", "ploc"]
 
 [dependencies]
 glam = { version = ">=0.29, <0.31", features = ["bytemuck"] }
-half = "2.3.1"
-bytemuck = { version = "1.23", features = ["derive", "extern_crate_alloc"] }
+half = "2.7"
+bytemuck = { version = "1.24", features = ["derive", "extern_crate_alloc"] }
 rdst = { version = "0.20.14", default-features = false }
-rayon = { version = "1.9.0", optional = true }
+rayon = { version = "1.11.0", optional = true }
 
 # Noop unless one of the profile-with features below is also used
 profiling = { version = "1.0", optional = true }
 
 [dev-dependencies]
-image = "0.24"
+image = "0.25"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,16 @@
 [package]
 name = "obvhs"
 version = "0.2.2"
-edition = "2021"
+edition = "2024"
 description = "BVH Construction and Traversal Library"
+
 homepage = "https://github.com/DGriffin91/obvhs"
 repository = "https://github.com/DGriffin91/obvhs"
 readme = "README.md"
+
 license = "MIT OR Apache-2.0"
 keywords = ["bvh", "sah", "aabb", "cwbvh", "ploc"]
+categories = ["rendering"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,7 @@ macro_rules! scope {
 }
 
 /// General build parameters for Bvh2 & CwBvh
+#[must_use]
 pub struct BvhBuildParams {
     /// Split large tris into multiple AABBs
     pub pre_split: bool,

--- a/src/triangle.rs
+++ b/src/triangle.rs
@@ -17,6 +17,7 @@ unsafe impl Zeroable for Triangle {}
 
 impl Triangle {
     /// Compute the normal of the triangle geometry.
+    #[must_use]
     #[inline(always)]
     pub fn compute_normal(&self) -> Vec3A {
         let e1 = self.v1 - self.v0;
@@ -25,6 +26,7 @@ impl Triangle {
     }
 
     /// Compute the bounding box of the triangle.
+    #[must_use]
     #[inline(always)]
     pub fn aabb(&self) -> Aabb {
         Aabb::from_points(&[self.v0, self.v1, self.v2])
@@ -32,6 +34,7 @@ impl Triangle {
 
     /// Find the distance (t) of the intersection of the `Ray` and this Triangle.
     /// Returns f32::INFINITY for miss.
+    #[must_use]
     #[inline(always)]
     pub fn intersect(&self, ray: &Ray) -> f32 {
         // TODO not very water tight from the back side in some contexts (tris with edges at 0,0,0 show 1px gap)
@@ -155,6 +158,7 @@ impl Triangle {
         f32::INFINITY
     }
 
+    #[must_use]
     #[inline(always)]
     pub fn compute_barycentric(&self, ray: &Ray) -> Vec2 {
         let e1 = self.v0 - self.v1;


### PR DESCRIPTION
This patch:
- Moves to Rust 2024 edition
- Updates dependencies
- Lints code, improving used warnings
