### PR TITLE
Handle many inf aabbs in bvh2 ploc

### DIFF
--- a/src/ploc/mod.rs
+++ b/src/ploc/mod.rs
@@ -7,6 +7,8 @@ pub mod morton;
 // https://meistdan.github.io/publications/ploc/paper.pdf
 // https://github.com/madmann91/bvh/blob/v1/include/bvh/locally_ordered_clustering_builder.hpp
 
+use core::f32;
+
 use glam::DVec3;
 use rdst::{RadixKey, RadixSort};
 
@@ -151,7 +153,7 @@ pub fn build_ploc_from_leafs<const SEARCH_DISTANCE: usize>(
         if SEARCH_DISTANCE == 1 || depth < search_depth_threshold {
             // TODO try making build_ploc_from_leafs_one that embeds this logic into
             // the main `while index < merge.len() {` loop  (may not be faster, tbd)
-            let mut last_cost = f32::MAX;
+            let mut last_cost = f32::INFINITY;
             let count = current_nodes.len() - 1;
             assert!(count < merge.len()); // Try to elide bounds check
             (0..count).for_each(|i| {
@@ -256,7 +258,7 @@ fn find_best_node_basic(index: usize, nodes: &[Bvh2Node], search_distance: usize
             continue;
         }
         let cost = our_aabb.union(&nodes[other].aabb).half_area();
-        if cost < best_cost {
+        if cost <= best_cost {
             best_node = other;
             best_cost = cost;
         }
@@ -333,7 +335,7 @@ impl<const SEARCH_DISTANCE: usize> SearchCache<SEARCH_DISTANCE> {
 
         for other in begin..index {
             let area = self.back(index, other);
-            if area < best_cost {
+            if area <= best_cost {
                 best_node = other;
                 best_cost = area;
             }
@@ -343,7 +345,7 @@ impl<const SEARCH_DISTANCE: usize> SearchCache<SEARCH_DISTANCE> {
         ((index + 1)..end).for_each(|other| {
             let cost = our_aabb.union(&nodes[other].aabb).half_area();
             *self.front(index, other) = cost;
-            if cost < best_cost {
+            if cost <= best_cost {
                 best_node = other;
                 best_cost = cost;
             }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -33,6 +33,28 @@ mod tests {
     }
 
     #[test]
+    pub fn build_bvh2_with_many_inf() {
+        let bvh = build_bvh2(
+            &[Aabb::INFINITY; 10],
+            BvhBuildParams::medium_build(),
+            &mut Duration::default(),
+        );
+        let ray = Ray::new_inf(Vec3A::Z, -Vec3A::Z);
+        assert!(!bvh.ray_traverse(ray, &mut RayHit::none(), |_ray, _id| f32::INFINITY));
+    }
+
+    #[test]
+    pub fn build_bvh2_with_many_max() {
+        let bvh = build_bvh2(
+            &[Aabb::LARGEST; 10],
+            BvhBuildParams::medium_build(),
+            &mut Duration::default(),
+        );
+        let ray = Ray::new_inf(Vec3A::Z, -Vec3A::Z);
+        assert!(!bvh.ray_traverse(ray, &mut RayHit::none(), |_ray, _id| f32::INFINITY));
+    }
+
+    #[test]
     pub fn build_cwbvh_with_empty_aabb() {
         let bvh = build_cwbvh(
             &[Aabb::empty()],


### PR DESCRIPTION
When there are multiple `Aabb::INFINITY` next to each other in the list of AABBs it could result the ploc builder not being able to find pairs correctly and then crashing.

It would crash at `next_nodes.push(current_nodes[index]);` from index wrapping around. Or at `debug_assert_ne!(best_index, index);` from a best index effectively not being selected at all.

This is still an issue with the CWBVH building because `f32::INFINITY - f32::INFINITY` is NaN, and for some other similar reasons to the bvh2 builder in `calculate_cost_impl()` and `order_children()`. Needs further investigation to determine if it's possible to cover this corner case without impacting performance in CWBVH. Note: `CwBvhNode::compute_extent()` can return an INF.

~~Need to test this PR with tray_racing before merging.~~ Tested with tray_racing. Some scene are slightly faster, others slightly slower. Likely just due to the resulting bvh structure not being identical. Rendered scenes in tray_racing match exactly.