### PR TITLE
Require at least glam 0.30.10 for Vec3A log2/exp2 to work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bvh", "sah", "aabb", "cwbvh", "ploc"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-glam = { version = ">=0.30, <0.32", features = ["bytemuck"] }
+glam = { version = ">=0.30.10, <0.32", features = ["bytemuck"] }
 half = "2"
 bytemuck = { version = "1", features = ["derive", "extern_crate_alloc"] }
 rdst = { version = "0.20", default-features = false }


### PR DESCRIPTION
`obvhs` currently uses `Vec3A.log2().ceil().exp2()` in [`src/cwbvh/bvh2_to_cwbvh.rs#L85-L88`](https://github.com/DGriffin91/obvhs/blob/v0.3.0/src/cwbvh/bvh2_to_cwbvh.rs#L85-L88).

According to the [`glam` changelog for 0.30.10](https://github.com/bitshifter/glam-rs/blob/0.32.1/CHANGELOG.md#03010---2026-01-07), float vector `exp2`, `ln`, and `log2` methods were added in `0.30.10`.

I hit this while upgrading avian3d from 0.4 to 0.6.1. My project already had an existing Cargo.lock, so Cargo kept resolving to glam v0.30.8, which made obvhs fail to compile. After removing the lockfile and re-resolving dependencies, Cargo selected newer compatible versions and the project built again.
