### PR TITLE
Dynamic update improvements to `Bvh2`

### DIFF
--- a/examples/physics.rs
+++ b/examples/physics.rs
@@ -69,9 +69,6 @@ struct Args {
     /// render on a single thread (control building parallelism with `--features parallel`)
     #[argh(switch)]
     single_threaded_render: bool,
-    /// disables tree rotations on the greedy insertion and move paths
-    #[argh(switch)]
-    no_rotate: bool,
 }
 
 fn main() {
@@ -441,16 +438,12 @@ impl PhysicsWorld {
     pub fn bvh_partial_rebuild_greedy_remove_insert(&mut self) {
         dbg_scope!("bvh_partial_rebuild_greedy_remove_insert");
         let oversize_factor = self.oversize_factor();
-        let should_rotate = !self.config.no_rotate;
         self.updated_leaves_this_frame = 0;
         for (primitive_id, item) in self.items.iter_mut().enumerate() {
             if item.update_oversized_aabb(oversize_factor) {
                 self.bvh.remove_primitive(primitive_id as u32);
-                self.bvh.insert_primitive_greedy(
-                    item.oversized_aabb,
-                    primitive_id as u32,
-                    should_rotate,
-                );
+                self.bvh
+                    .insert_primitive_greedy(item.oversized_aabb, primitive_id as u32);
                 self.updated_leaves_this_frame += 1;
             }
         }
@@ -459,13 +452,12 @@ impl PhysicsWorld {
     pub fn bvh_partial_rebuild_move(&mut self) {
         dbg_scope!("bvh_partial_rebuild_move");
         let oversize_factor = self.oversize_factor();
-        let should_rotate = !self.config.no_rotate;
         self.bvh.init_primitives_to_nodes_if_uninit();
         self.updated_leaves_this_frame = 0;
         for (primitive_id, item) in self.items.iter_mut().enumerate() {
             if item.update_oversized_aabb(oversize_factor) {
                 self.bvh
-                    .move_primitive(item.oversized_aabb, primitive_id as u32, should_rotate);
+                    .move_primitive(item.oversized_aabb, primitive_id as u32);
                 self.updated_leaves_this_frame += 1;
             }
         }

--- a/examples/physics.rs
+++ b/examples/physics.rs
@@ -41,7 +41,8 @@ struct Args {
     /// disables using the bvh for physics broad phase (still uses it for rendering)
     #[argh(switch)]
     no_physics_bvh: bool,
-    /// bvh update method. Modes: 'rebuild', 'reinsert', 'parallel_reinsert', 'remove_and_insert', "partial_rebuild"
+    /// bvh update method. Modes: 'rebuild', 'reinsert', 'parallel_reinsert', 'remove_and_insert',
+    /// 'greedy_remove_and_insert', 'move', 'partial_rebuild'
     #[argh(option, default = "BvhUpdate::Rebuild")]
     bvh_update: BvhUpdate,
     /// check that we got the same list of pairs from the bvh broad phase as brute force method
@@ -264,6 +265,8 @@ enum BvhUpdate {
     Reinsert,
     ParallelReinsert,
     RemoveAndInsert,
+    GreedyRemoveAndInsert,
+    Move,
     PartialRebuild,
 }
 
@@ -276,9 +279,12 @@ impl FromStr for BvhUpdate {
             "reinsert" => Ok(Self::Reinsert),
             "parallel_reinsert" => Ok(Self::ParallelReinsert),
             "remove_and_insert" => Ok(Self::RemoveAndInsert),
+            "greedy_remove_and_insert" => Ok(Self::GreedyRemoveAndInsert),
+            "move" => Ok(Self::Move),
             "partial_rebuild" => Ok(Self::PartialRebuild),
             _ => Err(format!(
-                "Unknown mode: '{s}', valid modes: 'rebuild', 'reinsert', 'remove_and_insert', 'partial_rebuild'"
+                "Unknown mode: '{s}', valid modes: 'rebuild', 'reinsert', 'parallel_reinsert', 'remove_and_insert', \
+'greedy_remove_and_insert', 'move', 'partial_rebuild'"
             )),
         }
     }
@@ -346,6 +352,8 @@ impl PhysicsWorld {
             BvhUpdate::Reinsert
             | BvhUpdate::ParallelReinsert
             | BvhUpdate::RemoveAndInsert
+            | BvhUpdate::GreedyRemoveAndInsert
+            | BvhUpdate::Move
             | BvhUpdate::PartialRebuild => self.items[id as usize].oversized_aabb,
         };
         self.bvh
@@ -427,6 +435,34 @@ impl PhysicsWorld {
         }
     }
 
+    pub fn bvh_partial_rebuild_greedy_remove_insert(&mut self) {
+        dbg_scope!("bvh_partial_rebuild_greedy_remove_insert");
+        let oversize_factor = self.oversize_factor();
+        self.updated_leaves_this_frame = 0;
+        for (primitive_id, item) in self.items.iter_mut().enumerate() {
+            if item.update_oversized_aabb(oversize_factor) {
+                self.bvh.remove_primitive(primitive_id as u32);
+                self.bvh
+                    .insert_primitive_greedy(item.oversized_aabb, primitive_id as u32);
+                self.updated_leaves_this_frame += 1;
+            }
+        }
+    }
+
+    pub fn bvh_partial_rebuild_move(&mut self) {
+        dbg_scope!("bvh_partial_rebuild_move");
+        let oversize_factor = self.oversize_factor();
+        self.bvh.init_primitives_to_nodes_if_uninit();
+        self.updated_leaves_this_frame = 0;
+        for (primitive_id, item) in self.items.iter_mut().enumerate() {
+            if item.update_oversized_aabb(oversize_factor) {
+                self.bvh
+                    .move_primitive(item.oversized_aabb, primitive_id as u32);
+                self.updated_leaves_this_frame += 1;
+            }
+        }
+    }
+
     pub fn bvh_partial_rebuild(&mut self) {
         dbg_scope!("bvh_partial_rebuild");
         let oversize_factor = self.oversize_factor();
@@ -460,6 +496,8 @@ impl PhysicsWorld {
             BvhUpdate::Reinsert
             | BvhUpdate::ParallelReinsert
             | BvhUpdate::RemoveAndInsert
+            | BvhUpdate::GreedyRemoveAndInsert
+            | BvhUpdate::Move
             | BvhUpdate::PartialRebuild => self.config.aabb_oversize,
         }
     }
@@ -535,6 +573,8 @@ fn physics_update(physics: &mut PhysicsWorld) {
         BvhUpdate::Reinsert => physics.bvh_partial_rebuild_reinsert(),
         BvhUpdate::ParallelReinsert => physics.bvh_partial_rebuild_parallel_reinsert(),
         BvhUpdate::RemoveAndInsert => physics.bvh_partial_rebuild_remove_insert(),
+        BvhUpdate::GreedyRemoveAndInsert => physics.bvh_partial_rebuild_greedy_remove_insert(),
+        BvhUpdate::Move => physics.bvh_partial_rebuild_move(),
         BvhUpdate::PartialRebuild => physics.bvh_partial_rebuild(),
     }
 

--- a/examples/physics.rs
+++ b/examples/physics.rs
@@ -64,11 +64,14 @@ struct Args {
     #[argh(option, default = "120")]
     fps_limit: usize,
     /// render resolution (width:height are 1:1)
-    #[argh(option, default = "512")]
+    #[argh(option, default = "1024")]
     render_res: usize,
     /// render on a single thread (control building parallelism with `--features parallel`)
     #[argh(switch)]
     single_threaded_render: bool,
+    /// disables tree rotations on the greedy insertion and move paths
+    #[argh(switch)]
+    no_rotate: bool,
 }
 
 fn main() {
@@ -438,12 +441,16 @@ impl PhysicsWorld {
     pub fn bvh_partial_rebuild_greedy_remove_insert(&mut self) {
         dbg_scope!("bvh_partial_rebuild_greedy_remove_insert");
         let oversize_factor = self.oversize_factor();
+        let should_rotate = !self.config.no_rotate;
         self.updated_leaves_this_frame = 0;
         for (primitive_id, item) in self.items.iter_mut().enumerate() {
             if item.update_oversized_aabb(oversize_factor) {
                 self.bvh.remove_primitive(primitive_id as u32);
-                self.bvh
-                    .insert_primitive_greedy(item.oversized_aabb, primitive_id as u32);
+                self.bvh.insert_primitive_greedy(
+                    item.oversized_aabb,
+                    primitive_id as u32,
+                    should_rotate,
+                );
                 self.updated_leaves_this_frame += 1;
             }
         }
@@ -452,12 +459,13 @@ impl PhysicsWorld {
     pub fn bvh_partial_rebuild_move(&mut self) {
         dbg_scope!("bvh_partial_rebuild_move");
         let oversize_factor = self.oversize_factor();
+        let should_rotate = !self.config.no_rotate;
         self.bvh.init_primitives_to_nodes_if_uninit();
         self.updated_leaves_this_frame = 0;
         for (primitive_id, item) in self.items.iter_mut().enumerate() {
             if item.update_oversized_aabb(oversize_factor) {
                 self.bvh
-                    .move_primitive(item.oversized_aabb, primitive_id as u32);
+                    .move_primitive(item.oversized_aabb, primitive_id as u32, should_rotate);
                 self.updated_leaves_this_frame += 1;
             }
         }

--- a/examples/physics.rs
+++ b/examples/physics.rs
@@ -64,7 +64,7 @@ struct Args {
     #[argh(option, default = "120")]
     fps_limit: usize,
     /// render resolution (width:height are 1:1)
-    #[argh(option, default = "1024")]
+    #[argh(option, default = "512")]
     render_res: usize,
     /// render on a single thread (control building parallelism with `--features parallel`)
     #[argh(switch)]

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -427,7 +427,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             )
         }
 
-        if !sibling.is_leaf() || left_id < sibling_id {
+        if left_id < sibling_id || (!sibling.is_leaf() && sibling.first_index as usize <= left_id) {
             // The sibling was moved, but its children stayed where they were,
             // so they may now come before their parent. The new pair may also
             // come before the new parent when reusing freed slots.
@@ -461,8 +461,6 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
 
         // Need to work up the tree updating the aabbs since we just removed a node.
         self.refit_from_fast(parent_id);
-
-        self.children_are_ordered_after_parents = false;
 
         Bvh2Node::get_left_sibling_id(node_id)
     }

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -647,8 +647,24 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             .max(sibling_depth + 2 + should_rotate as usize);
     }
 
-    /// Considers swapping one of the children of the node at `node_id` with one of the other child's children,
-    /// applying the cheapest of the four such rotations if it improves the total cost of the two inner nodes below `node_id`.
+    /// Computes the cost of a potential rotation around the node at `node_id`,
+    /// and applies it if it improves the total cost of the two inner nodes below `node_id`.
+    ///
+    /// This is a local restructuring of the tree that swaps one of the two children of `node_id`
+    /// with a child of the other (a grandchild of `node_id`). Given a tree of the form:
+    ///
+    /// ```text
+    ///     node
+    ///    /    \
+    ///   b      c
+    ///  / \    / \
+    /// d   e  f   g
+    ///
+    /// ```
+    ///
+    /// where `node_id` refers to `node`, four rotations are considered: swapping `b` with `f`,
+    /// `b` with `g`, `c` with `d`, and `c` with `e`. The minimum cost of the four is computed,
+    /// and if it is less than the current cost of `b` and `c`, the rotation is applied.
     ///
     /// This incrementally recovers the quality of the BVH as leaves are inserted or the tree is refit,
     /// and helps avoid degenerating depth.
@@ -668,13 +684,6 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             return None;
         }
 
-        // Initial subtree:
-        //
-        //     node
-        //    /    \
-        //   b      c
-        //  / \    / \
-        // d   e  f   g
         let b_id = node.first_index as usize;
         let c_id = b_id + 1;
         let b = self.nodes[b_id];
@@ -684,14 +693,21 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         let c_area = c.aabb().half_area();
         let mut best_cost = b_area + c_area;
 
+        struct RotationCandidate {
+            from: usize,
+            to: usize,
+            refit_id: usize,
+            refit_aabb: Aabb,
+        }
+
         // The two slots to swap, the node that ends up with a different pair of children, and the aabb it ends up with.
-        let mut best_rotation: Option<(usize, usize, usize, Aabb)> = None;
+        let mut best_rotation: Option<RotationCandidate> = None;
 
         if !c.is_leaf() {
             let f_id = c.first_index as usize;
             let g_id = f_id + 1;
-            let f_aabb = *self.nodes[f_id].aabb();
-            let g_aabb = *self.nodes[g_id].aabb();
+            let f_aabb = self.nodes[f_id].aabb();
+            let g_aabb = self.nodes[g_id].aabb();
 
             // Cost of swapping b and f, which leaves c covering b and g.
             //
@@ -702,11 +718,16 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             //          b   g
             //         / \
             //        d   e
-            let aabb_bg = b.aabb().union(&g_aabb);
+            let aabb_bg = b.aabb().union(g_aabb);
             let cost_bf = b_area + aabb_bg.half_area();
             if cost_bf < best_cost {
                 best_cost = cost_bf;
-                best_rotation = Some((b_id, f_id, c_id, aabb_bg));
+                best_rotation = Some(RotationCandidate {
+                    from: b_id,
+                    to: f_id,
+                    refit_id: c_id,
+                    refit_aabb: aabb_bg,
+                });
             }
 
             // Cost of swapping b and g, which leaves c covering b and f.
@@ -718,19 +739,24 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             //          f   b
             //             / \
             //            d   e
-            let aabb_bf = b.aabb().union(&f_aabb);
+            let aabb_bf = b.aabb().union(f_aabb);
             let cost_bg = b_area + aabb_bf.half_area();
             if cost_bg < best_cost {
                 best_cost = cost_bg;
-                best_rotation = Some((b_id, g_id, c_id, aabb_bf));
+                best_rotation = Some(RotationCandidate {
+                    from: b_id,
+                    to: g_id,
+                    refit_id: c_id,
+                    refit_aabb: aabb_bf,
+                });
             }
         }
 
         if !b.is_leaf() {
             let d_id = b.first_index as usize;
             let e_id = d_id + 1;
-            let d_aabb = *self.nodes[d_id].aabb();
-            let e_aabb = *self.nodes[e_id].aabb();
+            let d_aabb = self.nodes[d_id].aabb();
+            let e_aabb = self.nodes[e_id].aabb();
 
             // Cost of swapping c and d, which leaves b covering c and e.
             //
@@ -741,11 +767,16 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             //   c   e
             //  / \
             // f   g
-            let aabb_ce = c.aabb().union(&e_aabb);
+            let aabb_ce = c.aabb().union(e_aabb);
             let cost_cd = c_area + aabb_ce.half_area();
             if cost_cd < best_cost {
                 best_cost = cost_cd;
-                best_rotation = Some((c_id, d_id, b_id, aabb_ce));
+                best_rotation = Some(RotationCandidate {
+                    from: c_id,
+                    to: d_id,
+                    refit_id: b_id,
+                    refit_aabb: aabb_ce,
+                });
             }
 
             // Cost of swapping c and e, which leaves b covering c and d.
@@ -757,15 +788,26 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             //   d   c
             //      / \
             //     f   g
-            let aabb_cd = c.aabb().union(&d_aabb);
+            let aabb_cd = c.aabb().union(d_aabb);
             let cost_ce = c_area + aabb_cd.half_area();
             if cost_ce < best_cost {
                 // Last candidate, so best_cost doesn't need to be updated.
-                best_rotation = Some((c_id, e_id, b_id, aabb_cd));
+                best_rotation = Some(RotationCandidate {
+                    from: c_id,
+                    to: e_id,
+                    refit_id: b_id,
+                    refit_aabb: aabb_cd,
+                });
             }
         }
 
-        let Some((from, to, refit_id, refit_aabb)) = best_rotation else {
+        let Some(RotationCandidate {
+            from,
+            to,
+            refit_id,
+            refit_aabb,
+        }) = best_rotation
+        else {
             // No rotation improves the cost.
             return None;
         };

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -326,7 +326,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             let left_direct_cost = left_aabb.union(aabb).half_area();
             let right_direct_cost = right_aabb.union(aabb).half_area();
 
-            // Lower bound on the cost of inserting anywhere below each child.
+            // Lower bound on the cost of choosing a sibling from the subtree rooted at each child.
             // Left at f32::MAX for leaves since there is nothing below them to descend into.
             let mut left_lower_cost = f32::MAX;
             let mut right_lower_cost = f32::MAX;
@@ -342,6 +342,13 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
                 }
             } else {
                 left_area = left_aabb.half_area();
+
+                // Lower bound cost of choosing a sibling from the subtree rooted at the left child.
+                //
+                // This is the minimum of:
+                //
+                // 1. Choosing the child itself: inherited_cost + left_direct_cost
+                // 2. Choosing one of its descendants: inherited_cost + (left_direct_cost - left_area) + area
                 left_lower_cost = inherited_cost + left_direct_cost + (area - left_area).min(0.0);
             }
 
@@ -354,6 +361,8 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
                 }
             } else {
                 right_area = right_aabb.half_area();
+
+                // See above for left_lower_cost.
                 right_lower_cost =
                     inherited_cost + right_direct_cost + (area - right_area).min(0.0);
             }

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -129,8 +129,12 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// classified as the sibling that if chosen it would increase the surface area of the BVH the least.
     /// When the best sibling is found, a parent of both the sibling and the new node is put in the location of
     /// the sibling and both the sibling and new node are added to the end of the bvh.nodes.
-    /// See "Branch and Bound" <https://box2d.org/files/ErinCatto_DynamicBVH_Full.pdf>
+    ///
+    /// See "Branch and Bound" <https://box2d.org/files/ErinCatto_DynamicBVH_Full.pdf> and
     /// Jiˇrí Bittner et al. 2012 Fast Insertion-Based Optimization of Bounding Volume Hierarchies
+    ///
+    /// See [`Bvh2::insert_leaf_greedy()`] for a faster version that descends a single path,
+    /// and that rotates on the refit walk to keep the BVH from degenerating.
     ///
     /// # Returns
     /// The index of the newly added node (always `bvh.nodes.len() - 1` since the node it put at the end).
@@ -260,6 +264,450 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         new_node_id
     }
 
+    /// Searches the tree for the best sibling for a leaf with the given `aabb` using a greedy top-down descent.
+    /// The best sibling is classified as the sibling that if chosen it would increase the surface area of the BVH the least.
+    ///
+    /// Unlike the branch and bound search in [`Bvh2::insert_leaf()`], this only ever descends a single path from the root,
+    /// always taking the child with the lower bound on what inserting beneath it could cost, and stopping as soon as
+    /// neither child's bound can beat the best candidate already found. This is O(depth), needs no traversal stack,
+    /// and doesn't blow up the same way as the BVH gets deeper. However, it tends to find a slightly worse sibling
+    /// than the branch and bound search.
+    ///
+    /// # Returns
+    /// The index of the best sibling found, and the depth it was found at (the root has a depth of 0).
+    ///
+    /// # Arguments
+    /// * `aabb` - The aabb of the leaf that is going to be inserted.
+    pub fn find_sibling_greedy(&self, aabb: &Aabb) -> (usize, usize) {
+        // This is based on `b2FindBestSibling` in Box2D by Erin Catto.
+
+        let center = aabb.center();
+        let area = aabb.half_area();
+
+        let root_aabb = self.nodes[0].aabb();
+
+        // Area of the node currently being descended into.
+        let mut area_base = root_aabb.half_area();
+
+        // Area of that node once it has been inflated to also contain the new leaf.
+        let mut direct_cost = root_aabb.union(aabb).half_area();
+
+        // How much every node from the root down to the current node would have to grow.
+        let mut inherited_cost = 0.0;
+
+        let mut best_cost = direct_cost;
+        let mut best_sibling_candidate_id = 0;
+        let mut best_sibling_candidate_depth = 0;
+
+        let mut current_node_index = 0;
+        let mut depth = 0;
+
+        // Descend the tree from the root, following a single greedy path.
+        while !self.nodes[current_node_index].is_leaf() {
+            let left_id = self.nodes[current_node_index].first_index as usize;
+            let right_id = left_id + 1;
+
+            // Cost of creating a new parent for this node and the new leaf.
+            let total_cost = direct_cost + inherited_cost;
+            if total_cost < best_cost {
+                best_cost = total_cost;
+                best_sibling_candidate_id = current_node_index;
+                best_sibling_candidate_depth = depth;
+            }
+
+            inherited_cost += direct_cost - area_base;
+
+            let left_is_leaf = self.nodes[left_id].is_leaf();
+            let right_is_leaf = self.nodes[right_id].is_leaf();
+            let left_aabb = *self.nodes[left_id].aabb();
+            let right_aabb = *self.nodes[right_id].aabb();
+            let left_direct_cost = left_aabb.union(aabb).half_area();
+            let right_direct_cost = right_aabb.union(aabb).half_area();
+
+            // Lower bound on the cost of inserting anywhere below each child.
+            // Left at f32::MAX for leaves since there is nothing below them to descend into.
+            let mut left_lower_cost = f32::MAX;
+            let mut right_lower_cost = f32::MAX;
+            let mut left_area = 0.0;
+            let mut right_area = 0.0;
+
+            if left_is_leaf {
+                let cost = left_direct_cost + inherited_cost;
+                if cost < best_cost {
+                    best_cost = cost;
+                    best_sibling_candidate_id = left_id;
+                    best_sibling_candidate_depth = depth + 1;
+                }
+            } else {
+                left_area = left_aabb.half_area();
+                left_lower_cost = inherited_cost + left_direct_cost + (area - left_area).min(0.0);
+            }
+
+            if right_is_leaf {
+                let cost = right_direct_cost + inherited_cost;
+                if cost < best_cost {
+                    best_cost = cost;
+                    best_sibling_candidate_id = right_id;
+                    best_sibling_candidate_depth = depth + 1;
+                }
+            } else {
+                right_area = right_aabb.half_area();
+                right_lower_cost =
+                    inherited_cost + right_direct_cost + (area - right_area).min(0.0);
+            }
+
+            if best_cost <= left_lower_cost && best_cost <= right_lower_cost {
+                // Neither subtree can beat the best candidate already found.
+                break;
+            }
+
+            if left_lower_cost == right_lower_cost && !left_is_leaf {
+                // The bounds give no clear choice, which happens when both children
+                // fully contain `aabb`. Fall back to the child whose center is closest.
+                left_lower_cost = (left_aabb.center() - center).length_squared();
+                right_lower_cost = (right_aabb.center() - center).length_squared();
+            }
+
+            // Descend into the more promising child.
+            if left_lower_cost < right_lower_cost && !left_is_leaf {
+                current_node_index = left_id;
+                area_base = left_area;
+                direct_cost = left_direct_cost;
+            } else {
+                current_node_index = right_id;
+                area_base = right_area;
+                direct_cost = right_direct_cost;
+            }
+
+            depth += 1;
+        }
+
+        (best_sibling_candidate_id, best_sibling_candidate_depth)
+    }
+
+    /// Attaches `new_node` to the BVH as the new sibling of the node at `sibling_id`.
+    ///
+    /// The new parent takes the sibling's slot, so nothing above `sibling_id` moves.
+    /// The displaced sibling and `new_node` are put in the adjacent pair of slots
+    /// at `left_id` and `left_id + 1`. Both of those slots have to already exist
+    /// and must not be reachable from the root.
+    ///
+    /// # Returns
+    /// The index of the newly attached node (always `left_id + 1`).
+    fn attach_leaf(&mut self, new_node: Bvh2Node, sibling_id: usize, left_id: usize) -> usize {
+        debug_assert!(Bvh2Node::is_left_sibling(left_id));
+
+        let new_node_id = left_id + 1;
+        let sibling = self.nodes[sibling_id];
+
+        // New parent goes in the sibling's position.
+        self.nodes[sibling_id] =
+            Bvh2Node::new(new_node.aabb().union(sibling.aabb()), 0, left_id as u32);
+        self.nodes[left_id] = sibling;
+        self.nodes[new_node_id] = new_node;
+        self.parents[left_id] = sibling_id as u32;
+        self.parents[new_node_id] = sibling_id as u32;
+
+        // Tell the children (or primitives) of the moved sibling where it went.
+        self.relink(left_id);
+
+        // if primitives_to_nodes has already been initialized
+        if !self.primitives_to_nodes.is_empty() {
+            // Tell primitives where their node went.
+            let end = new_node.first_index + new_node.prim_count;
+            if self.primitives_to_nodes.len() < end as usize {
+                // Since we are adding a primitive it's possible that primitives_to_nodes is not large enough yet.
+                self.primitives_to_nodes.resize(end as usize, INVALID);
+            }
+            update_primitives_to_nodes_for_node(
+                &new_node,
+                new_node_id,
+                &self.primitive_indices,
+                &mut self.primitives_to_nodes,
+            )
+        }
+
+        if !sibling.is_leaf() || left_id < sibling_id {
+            // The sibling was moved, but its children stayed where they were,
+            // so they may now come before their parent. The new pair may also
+            // come before the new parent when reusing freed slots.
+            self.children_are_ordered_after_parents = false;
+        }
+
+        new_node_id
+    }
+
+    /// Searches the tree with the greedy descent in [`Bvh2::find_sibling_greedy()`] to find a sibling
+    /// for the node being inserted, then attaches it there and rotates on the refit walk back up to the root.
+    ///
+    /// This is the greedy counterpart of [`Bvh2::insert_leaf()`]. It doesn't need a traversal stack,
+    /// it keeps [`Bvh2::max_depth`] up to date, and it keeps the BVH from degenerating as leaves are inserted,
+    /// at the cost of sometimes picking a slightly worse sibling.
+    ///
+    /// # Returns
+    /// The index of the newly added node.
+    ///
+    /// # Arguments
+    /// * `new_node` - This node must be a leaf and already have a valid `first_index` into `primitive_indices`.
+    pub fn insert_leaf_greedy(&mut self, new_node: Bvh2Node) -> usize {
+        assert!(new_node.is_leaf());
+
+        if self.nodes.is_empty() {
+            self.nodes.push(new_node);
+            self.parents.clear();
+            self.parents.push(0);
+            return 0;
+        }
+
+        self.init_parents_if_uninit();
+
+        let (sibling_id, sibling_depth) = self.find_sibling_greedy(new_node.aabb());
+
+        // Grow by an adjacent pair at the end for the displaced sibling and the new node.
+        // The node count is always odd, so the first of the two is always a left sibling.
+        let left_id = self.nodes.len();
+        self.nodes.push(Default::default());
+        self.nodes.push(Default::default());
+        self.parents.push(0);
+        self.parents.push(0);
+
+        let new_node_id = self.attach_leaf(new_node, sibling_id, left_id);
+        self.update_max_depth_for_greedy_insertion(sibling_depth);
+
+        // Need to work up the tree updating the aabbs since we just added a node.
+        // A rotation along the way can move the node we just attached, so we track it.
+        self.refit_and_rotate_from_tracking(sibling_id, new_node_id)
+    }
+
+    /// Searches the tree with the greedy descent in [`Bvh2::find_sibling_greedy()`] to find a sibling
+    /// for the primitive being inserted, then attaches it there and rotates on the refit walk back up to the root.
+    /// Updates [`Bvh2::primitive_indices`] and [`Bvh2::primitive_indices_freelist`].
+    ///
+    /// This is the greedy counterpart of [`Bvh2::insert_primitive()`]. It doesn't need a traversal stack,
+    /// it keeps [`Bvh2::max_depth`] up to date, and it keeps the BVH from degenerating as leaves are inserted,
+    /// at the cost of sometimes picking a slightly worse sibling.
+    ///
+    /// # Returns
+    /// The index of the newly added node.
+    ///
+    /// # Arguments
+    /// * `aabb` - The aabb of the primitive being inserted.
+    /// * `primitive_id` - The index of the primitive being inserted.
+    pub fn insert_primitive_greedy(&mut self, aabb: Aabb, primitive_id: u32) -> usize {
+        self.init_primitives_to_nodes_if_uninit();
+        self.init_parents_if_uninit();
+        if self.primitives_to_nodes.len() <= primitive_id as usize {
+            self.primitives_to_nodes
+                .resize(primitive_id as usize + 1, INVALID);
+        }
+        let first_index = if let Some(free_slot) = self.primitive_indices_freelist.pop() {
+            self.primitive_indices[free_slot as usize] = primitive_id;
+            free_slot
+        } else {
+            self.primitive_indices.push(primitive_id);
+            self.primitive_indices.len() as u32 - 1
+        };
+        let new_node_id = self.insert_leaf_greedy(Bvh2Node::new(aabb, 1, first_index));
+        self.primitives_to_nodes[primitive_id as usize] = new_node_id as u32;
+        new_node_id
+    }
+
+    /// Grows [`Bvh2::max_depth`] to account for a leaf that was just inserted below a sibling
+    /// at `sibling_depth`, where the root has a depth of 0.
+    ///
+    /// Note this is an upper bound estimate, not a strict bound. If the sibling is an inner node,
+    /// its whole subtree is pushed one level deeper too, and the greedy descent never visits that subtree,
+    /// so its height isn't known here.
+    #[inline]
+    fn update_max_depth_for_greedy_insertion(&mut self, sibling_depth: usize) {
+        // + 1 for the new leaf below the sibling
+        // + 1 for a rotation that may push it one level deeper
+        // + 1 because `max_depth` is a traversal stack size rather than a node depth
+        self.max_depth = self.max_depth.max(sibling_depth + 3);
+    }
+
+    /// Considers swapping one of the children of the node at `node_id` with one of the other child's children,
+    /// applying the cheapest of the four such rotations if it improves the total cost of the two inner nodes below `node_id`.
+    ///
+    /// This incrementally recovers the quality of the BVH as leaves are inserted or the tree is refit,
+    /// and helps avoid degenerating depth.
+    ///
+    /// # Returns
+    /// The two slots whose contents were swapped, if a rotation was applied. Any node id held by the caller
+    /// that is one of the two needs to be updated to the other.
+    ///
+    /// # Arguments
+    /// * `node_id` - The index into `self.nodes` of the node to rotate around. Does nothing for leaves,
+    ///   or for nodes whose children are both leaves.
+    pub fn rotate_node(&mut self, node_id: usize) -> Option<(usize, usize)> {
+        // This is based on `b2RotateNodes` in Box2D by Erin Catto.
+
+        let node = self.nodes[node_id];
+        if node.is_leaf() {
+            return None;
+        }
+
+        // Initial subtree:
+        //
+        //     node
+        //    /    \
+        //   b      c
+        //  / \    / \
+        // d   e  f   g
+        let b_id = node.first_index as usize;
+        let c_id = b_id + 1;
+        let b = self.nodes[b_id];
+        let c = self.nodes[c_id];
+
+        let b_area = b.aabb().half_area();
+        let c_area = c.aabb().half_area();
+        let mut best_cost = b_area + c_area;
+
+        // The two slots to swap, the node that ends up with a different pair of children, and the aabb it ends up with.
+        let mut best_rotation: Option<(usize, usize, usize, Aabb)> = None;
+
+        if !c.is_leaf() {
+            let f_id = c.first_index as usize;
+            let g_id = f_id + 1;
+            let f_aabb = *self.nodes[f_id].aabb();
+            let g_aabb = *self.nodes[g_id].aabb();
+
+            // Cost of swapping b and f, which leaves c covering b and g.
+            //
+            //       node
+            //      /    \
+            //     f      c
+            //           / \
+            //          b   g
+            //         / \
+            //        d   e
+            let aabb_bg = b.aabb().union(&g_aabb);
+            let cost_bf = b_area + aabb_bg.half_area();
+            if cost_bf < best_cost {
+                best_cost = cost_bf;
+                best_rotation = Some((b_id, f_id, c_id, aabb_bg));
+            }
+
+            // Cost of swapping b and g, which leaves c covering b and f.
+            //
+            //       node
+            //      /    \
+            //     g      c
+            //           / \
+            //          f   b
+            //             / \
+            //            d   e
+            let aabb_bf = b.aabb().union(&f_aabb);
+            let cost_bg = b_area + aabb_bf.half_area();
+            if cost_bg < best_cost {
+                best_cost = cost_bg;
+                best_rotation = Some((b_id, g_id, c_id, aabb_bf));
+            }
+        }
+
+        if !b.is_leaf() {
+            let d_id = b.first_index as usize;
+            let e_id = d_id + 1;
+            let d_aabb = *self.nodes[d_id].aabb();
+            let e_aabb = *self.nodes[e_id].aabb();
+
+            // Cost of swapping c and d, which leaves b covering c and e.
+            //
+            //       node
+            //      /    \
+            //     b      d
+            //    / \
+            //   c   e
+            //  / \
+            // f   g
+            let aabb_ce = c.aabb().union(&e_aabb);
+            let cost_cd = c_area + aabb_ce.half_area();
+            if cost_cd < best_cost {
+                best_cost = cost_cd;
+                best_rotation = Some((c_id, d_id, b_id, aabb_ce));
+            }
+
+            // Cost of swapping c and e, which leaves b covering c and d.
+            //
+            //       node
+            //      /    \
+            //     b      e
+            //    / \
+            //   d   c
+            //      / \
+            //     f   g
+            let aabb_cd = c.aabb().union(&d_aabb);
+            let cost_ce = c_area + aabb_cd.half_area();
+            if cost_ce < best_cost {
+                // Last candidate, so best_cost doesn't need to be updated.
+                best_rotation = Some((c_id, e_id, b_id, aabb_cd));
+            }
+        }
+
+        let Some((from, to, refit_id, refit_aabb)) = best_rotation else {
+            // No rotation improves the cost.
+            return None;
+        };
+
+        // Box2D reassigns child pointers, but obvhs stores children as an adjacent pair.
+        // Swapping the contents of the two slots has the same structural effect.
+        self.nodes.swap(from, to);
+        self.relink(from);
+        self.relink(to);
+
+        // Only the node that took on a different pair of children needs its aabb recomputed.
+        self.nodes[refit_id].set_aabb(refit_aabb);
+
+        self.children_are_ordered_after_parents = false;
+
+        Some((from, to))
+    }
+
+    /// Refit the BVH working up the tree from this node, ignoring leaves,
+    /// performing rotations at each node along the way where beneficial.
+    ///
+    /// This can only be used to refit when a single node has changed or moved.
+    ///
+    /// See [`Bvh2::rotate_node()`] and [`Bvh2::refit_from()`].
+    pub fn refit_and_rotate_from(&mut self, index: usize) {
+        self.refit_and_rotate_from_tracking(index, INVALID as usize);
+    }
+
+    /// Same as [`Bvh2::refit_and_rotate_from()`], but follows the node at `tracked_node_id`
+    /// through any rotations applied along the way.
+    ///
+    /// # Returns
+    /// The index that the tracked node ended up at.
+    fn refit_and_rotate_from_tracking(
+        &mut self,
+        mut index: usize,
+        mut tracked_node_id: usize,
+    ) -> usize {
+        self.init_parents_if_uninit();
+        loop {
+            let node = self.nodes[index];
+            if !node.is_leaf() {
+                let first_child_bbox = *self.nodes[node.first_index as usize].aabb();
+                let second_child_bbox = *self.nodes[node.first_index as usize + 1].aabb();
+                self.nodes[index].set_aabb(first_child_bbox.union(&second_child_bbox));
+
+                // A rotation only swaps nodes below `index`, so the computed aabb stays valid.
+                if let Some((from, to)) = self.rotate_node(index) {
+                    if tracked_node_id == from {
+                        tracked_node_id = to;
+                    } else if tracked_node_id == to {
+                        tracked_node_id = from;
+                    }
+                }
+            }
+            if index == 0 {
+                break;
+            }
+            index = self.parents[index] as usize;
+        }
+        tracked_node_id
+    }
+
     /// Removes the leaf that contains the given primitive. Should be correct for nodes with multiple primitives per
     /// leaf but faster for nodes with only one primitive per leaf, and will leave node aabb oversized.
     /// Updates Bvh2::primitive_indices and Bvh2::primitive_indices_freelist.
@@ -365,6 +813,8 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
 /// Dramatically slower than ploc at both building and traversal. Easily 10x or 100x slower at building.
 /// (goes up by something like n^3 after a certain threshold).
 /// (BVH quality still improved afterward lot by reinsertion/collapse).
+///
+/// See [`build_bvh2_by_greedy_insertion()`] which doesn't have either issue.
 #[doc(hidden)]
 pub fn build_bvh2_by_insertion<T: Boundable>(primitives: &[T]) -> Bvh2 {
     let mut bvh = Bvh2::default();
@@ -377,6 +827,27 @@ pub fn build_bvh2_by_insertion<T: Boundable>(primitives: &[T]) -> Bvh2 {
 
     // Update max depth for validate
     bvh.max_depth = (bvh.depth(0) + 1).max(DEFAULT_MAX_STACK_DEPTH);
+
+    #[cfg(debug_assertions)]
+    {
+        bvh.validate(primitives, false, true);
+    }
+
+    bvh
+}
+
+/// Same as [`build_bvh2_by_insertion()`],  but with the greedy sibling search and rotations,
+/// just for testing insertion.
+///
+/// Still slow at building compared to ploc, but uses a faster sibling search, and doesn't degenerate
+/// the way plain insertion does.
+#[doc(hidden)]
+pub fn build_bvh2_by_greedy_insertion<T: Boundable>(primitives: &[T]) -> Bvh2 {
+    let mut bvh = Bvh2::default();
+
+    for prim_id in 0..primitives.len() {
+        bvh.insert_primitive_greedy(primitives[prim_id].aabb(), prim_id as u32);
+    }
 
     #[cfg(debug_assertions)]
     {
@@ -415,8 +886,21 @@ pub fn slow_leaf_reinsertion(bvh: &mut Bvh2) {
 mod tests {
     use std::time::Duration;
 
+    use glam::vec3a;
+
     use super::*;
     use crate::{BvhBuildParams, bvh2::builder::build_bvh2, test_util::geometry::demoscene};
+
+    /// `count` unit boxes laid out in sorted order along a line.
+    /// This is the input that degenerates a rotation-free insertion build into a list.
+    fn sorted_boxes(count: usize) -> Vec<Aabb> {
+        (0..count)
+            .map(|i| {
+                let center = vec3a(i as f32, 0.0, 0.0);
+                Aabb::new(center - 0.5, center + 0.5)
+            })
+            .collect()
+    }
 
     #[test]
     fn build_by_insertion() {
@@ -424,6 +908,15 @@ mod tests {
             let tris = demoscene(res, 0);
             let bvh = build_bvh2_by_insertion(&tris);
             bvh.validate(&tris, false, false);
+        }
+    }
+
+    #[test]
+    fn build_by_greedy_insertion() {
+        for res in 30..=32 {
+            let tris = demoscene(res, 0);
+            let bvh = build_bvh2_by_greedy_insertion(&tris);
+            bvh.validate(&tris, false, true);
         }
     }
 
@@ -585,6 +1078,75 @@ mod tests {
                     "node {node_id} does not fit its children after refit_all()"
                 );
             }
+        }
+    }
+
+    #[test]
+    fn greedy_insertion_maintains_max_depth() {
+        // The greedy descent knows the depth of the sibling it picked, so insertion can keep `max_depth` up to date.
+        // Bvh2::validate() requires it to be a valid stack size, so a stale `max_depth` would fail the validation below.
+        let tris = demoscene(32, 0);
+        let bvh = build_bvh2_by_greedy_insertion(&tris);
+
+        assert!(
+            bvh.depth(0) <= bvh.max_depth,
+            "max_depth ({}) does not cover the actual bvh depth ({})",
+            bvh.max_depth,
+            bvh.depth(0)
+        );
+        bvh.validate(&tris, false, true);
+    }
+
+    #[test]
+    fn rotations_prevent_degenerate_bvh() {
+        // With plain insertion, sorted input degenerates the BVH into a list.
+        // Greedy insertion rotates on the refit walk, which recovers the quality incrementally.
+        let boxes = sorted_boxes(1024);
+
+        let mut with_rotations = Bvh2::default();
+        for (prim_id, aabb) in boxes.iter().enumerate() {
+            with_rotations.insert_primitive_greedy(*aabb, prim_id as u32);
+        }
+        with_rotations.validate(&boxes, false, true);
+
+        let mut without_rotations = Bvh2::default();
+        let mut stack = HeapStack::new_with_capacity(1000);
+        for (prim_id, aabb) in boxes.iter().enumerate() {
+            without_rotations.insert_primitive(*aabb, prim_id as u32, &mut stack);
+        }
+
+        let rotated_depth = with_rotations.depth(0);
+        let unrotated_depth = without_rotations.depth(0);
+
+        // This is 11 vs 513 at the time of writing, but for the test,
+        // pinning exact numbers probably isn't worthwile.
+        assert!(
+            rotated_depth * 45 < unrotated_depth,
+            "rotations should keep the bvh far shallower: {rotated_depth} vs {unrotated_depth}"
+        );
+    }
+
+    #[test]
+    fn rotate_node_preserves_aabbs() {
+        let tris = demoscene(24, 0);
+
+        let mut bvh = build_bvh2(
+            &tris,
+            BvhBuildParams::fastest_build(),
+            &mut Duration::default(),
+        );
+        bvh.init_primitives_to_nodes_if_uninit();
+        bvh.init_parents_if_uninit();
+
+        for node_id in 0..bvh.nodes.len() {
+            let aabb = *bvh.nodes[node_id].aabb();
+            bvh.rotate_node(node_id);
+            assert_eq!(
+                *bvh.nodes[node_id].aabb(),
+                aabb,
+                "rotating node {node_id} changed its aabb"
+            );
+            bvh.validate(&tris, false, true);
         }
     }
 }

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -437,6 +437,103 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         new_node_id
     }
 
+    /// Detaches the leaf at `node_id` without compacting `Bvh2::nodes`.
+    ///
+    /// The sibling takes the parent's slot, and the slots at `node_id` and its sibling then fall free.
+    /// They are unreachable from the root, so nothing can select one of them as an insertion sibling.
+    ///
+    /// Doesn't update the `primitive_indices` mapping, and leaves the `primitives_to_nodes` entries of the detached leaf
+    /// pointing at `node_id`. Both are still valid if the leaf is immediately reattached, see [`Bvh2::move_leaf()`].
+    ///
+    /// # Returns
+    /// The index of the left slot of the freed pair.
+    fn detach_leaf(&mut self, node_id: usize) -> usize {
+        let sibling_id = Bvh2Node::get_sibling_id(node_id);
+        debug_assert_eq!(
+            self.parents[node_id], self.parents[sibling_id],
+            "Both children should already have the same parent."
+        );
+        let parent_id = self.parents[node_id] as usize;
+
+        // Put sibling in parent's place (parent doesn't exist anymore)
+        self.nodes[parent_id] = self.nodes[sibling_id];
+        self.relink(parent_id);
+
+        // Need to work up the tree updating the aabbs since we just removed a node.
+        self.refit_from_fast(parent_id);
+
+        self.children_are_ordered_after_parents = false;
+
+        Bvh2Node::get_left_sibling_id(node_id)
+    }
+
+    /// Moves the leaf specified by `node_id` to a new position in the BVH, resizing it to `aabb`.
+    /// This is the fused equivalent of [`Bvh2::remove_leaf()`] followed by [`Bvh2::insert_leaf_greedy()`].
+    ///
+    /// `Bvh2::nodes.len()` is unchanged across the call and `Bvh2::primitive_indices` is untouched.
+    /// Uses the greedy sibling search ([`Bvh2::find_sibling_greedy()`]) and rotates on the refit walk ([`Bvh2::refit_and_rotate_from()`]).
+    ///
+    /// # Returns
+    /// The index of the moved node.
+    ///
+    /// # Arguments
+    /// * `node_id` - The index into `self.nodes` of the leaf being moved.
+    /// * `aabb` - The new aabb of the leaf.
+    pub fn move_leaf(&mut self, node_id: usize, aabb: Aabb) -> usize {
+        assert!(
+            !self.uses_spatial_splits,
+            "Moving leaves while using spatial splits is currently unsupported as it would require a mapping \
+from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
+        );
+
+        let mut node = self.nodes[node_id];
+        assert!(node.is_leaf());
+        node.set_aabb(aabb);
+
+        if self.nodes.len() == 1 {
+            self.nodes[0] = node;
+            return 0;
+        }
+        debug_assert_ne!(node_id, 0);
+
+        self.init_parents_if_uninit();
+
+        let left_id = self.detach_leaf(node_id);
+        let (sibling_id, sibling_depth) = self.find_sibling_greedy(node.aabb());
+        let new_node_id = self.attach_leaf(node, sibling_id, left_id);
+        self.update_max_depth_for_greedy_insertion(sibling_depth);
+
+        // Need to work up the tree updating the aabbs since we just added a node.
+        // A rotation along the way can move the node we just attached, so we track it.
+        self.refit_and_rotate_from_tracking(sibling_id, new_node_id)
+    }
+
+    /// Moves the leaf that contains the given primitive to a new position in the BVH, resizing it to `aabb`.
+    /// This is the fused equivalent of [`Bvh2::remove_primitive()`] followed by [`Bvh2::insert_primitive_greedy()`].
+    /// The whole leaf is moved, so this requires that the leaf contains only this primitive.
+    ///
+    /// # Returns
+    /// The new index of the node of this primitive.
+    ///
+    /// # Arguments
+    /// * `aabb` - The new aabb of the primitive.
+    /// * `primitive_id` - The index of the primitive being moved.
+    pub fn move_primitive(&mut self, aabb: Aabb, primitive_id: u32) -> usize {
+        self.init_primitives_to_nodes_if_uninit();
+        self.init_parents_if_uninit();
+        let node_id = self.primitives_to_nodes[primitive_id as usize] as usize;
+        assert_eq!(
+            self.nodes[node_id].prim_count, 1,
+            "Bvh2::move_primitive() would move the other primitives in this leaf along with it."
+        );
+        let new_node_id = self.move_leaf(node_id, aabb);
+        debug_assert_eq!(
+            self.primitives_to_nodes[primitive_id as usize],
+            new_node_id as u32
+        );
+        new_node_id
+    }
+
     /// Searches the tree with the greedy descent in [`Bvh2::find_sibling_greedy()`] to find a sibling
     /// for the node being inserted, then attaches it there and rotates on the refit walk back up to the root.
     ///
@@ -1148,5 +1245,59 @@ mod tests {
             );
             bvh.validate(&tris, false, true);
         }
+    }
+
+    #[test]
+    fn move_all_primitives() {
+        let tris = demoscene(16, 0);
+
+        let mut bvh = build_bvh2(
+            &tris,
+            BvhBuildParams::fastest_build(),
+            &mut Duration::default(),
+        );
+        bvh.init_primitives_to_nodes_if_uninit();
+        bvh.init_parents_if_uninit();
+        bvh.validate(&tris, false, false);
+
+        let node_count = bvh.nodes.len();
+        let primitive_indices = bvh.primitive_indices.clone();
+
+        // Move every primitive to a grown aabb, then back to its original one.
+        for primitive_id in 0..tris.len() as u32 {
+            let mut aabb = tris[primitive_id as usize].aabb();
+            aabb.min -= 0.05;
+            aabb.max += 0.05;
+            bvh.move_primitive(aabb, primitive_id);
+            assert_eq!(bvh.nodes.len(), node_count);
+            bvh.validate_parents();
+            bvh.validate_primitives_to_nodes();
+        }
+        for primitive_id in 0..tris.len() as u32 {
+            bvh.move_primitive(tris[primitive_id as usize].aabb(), primitive_id);
+            assert_eq!(bvh.nodes.len(), node_count);
+        }
+
+        assert_eq!(bvh.primitive_indices, primitive_indices);
+        bvh.validate(&tris, false, true);
+    }
+
+    #[test]
+    fn move_leaf_with_single_node_bvh() {
+        let tris = demoscene(16, 0);
+
+        let mut bvh = Bvh2::default();
+        bvh.insert_primitive_greedy(tris[0].aabb(), 0);
+        assert_eq!(bvh.nodes.len(), 1);
+
+        let mut aabb = tris[0].aabb();
+        aabb.max += 1.0;
+        assert_eq!(bvh.move_leaf(0, aabb), 0);
+        assert_eq!(bvh.nodes.len(), 1);
+        assert_eq!(*bvh.nodes[0].aabb(), aabb);
+
+        bvh.insert_primitive_greedy(tris[1].aabb(), 1);
+        bvh.move_primitive(tris[0].aabb(), 0);
+        bvh.validate(&tris[0..2], false, true);
     }
 }

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -62,22 +62,10 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         let mut parent_id = self.parents[node_id] as usize;
 
         // Put sibling in parent's place (parent doesn't exist anymore)
-        self.nodes[parent_id] = self.nodes[sibling_id];
-        let sibling = &mut self.nodes[parent_id];
-        if sibling.is_leaf() {
-            // Tell primitives where their node went.
-            update_primitives_to_nodes_for_node(
-                sibling,
-                parent_id,
-                &self.primitive_indices,
-                &mut self.primitives_to_nodes,
-            )
-        } else {
-            // Tell children of sibling where their parent went.
-            let left_sibling_child = sibling.first_index as usize;
-            self.parents[left_sibling_child] = parent_id as u32;
-            self.parents[left_sibling_child + 1] = parent_id as u32;
-        }
+        let sibling = self.nodes[sibling_id];
+        self.nodes[parent_id] = sibling;
+        // Tell the children (or primitives) of the moved sibling where it went.
+        self.relink_node(&sibling, parent_id);
         // Don't need to update other parents here since the parent that was for this `parent_id` slot is now the direct
         // parent of the moved sibling, and the parents of `node_id` and `sibling_id` are updated below.
 
@@ -111,36 +99,14 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             self.nodes[src_left_parent as usize].first_index = dst_left_id as u32;
 
             let right_src_sibling = self.nodes.pop().unwrap(); // Last node is right src sibling
-            if right_src_sibling.is_leaf() {
-                // Tell primitives where their node went.
-                update_primitives_to_nodes_for_node(
-                    &right_src_sibling,
-                    dst_right_id,
-                    &self.primitive_indices,
-                    &mut self.primitives_to_nodes,
-                );
-            } else {
-                // Go to children of right_src_sibling and tell them where their parent went
-                self.parents[right_src_sibling.first_index as usize] = dst_right_id as u32;
-                self.parents[right_src_sibling.first_index as usize + 1] = dst_right_id as u32;
-            }
             self.nodes[dst_right_id] = right_src_sibling;
+            // Tell the children (or primitives) of the moved right_src_sibling where it went.
+            self.relink_node(&right_src_sibling, dst_right_id);
 
             let left_src_sibling = self.nodes.pop().unwrap(); // Last node is left src sibling
-            if left_src_sibling.is_leaf() {
-                // Tell primitives where their node went.
-                update_primitives_to_nodes_for_node(
-                    &left_src_sibling,
-                    dst_left_id,
-                    &self.primitive_indices,
-                    &mut self.primitives_to_nodes,
-                );
-            } else {
-                // Go to children of left_src_sibling and tell them where their parent went
-                self.parents[left_src_sibling.first_index as usize] = dst_left_id as u32;
-                self.parents[left_src_sibling.first_index as usize + 1] = dst_left_id as u32;
-            }
             self.nodes[dst_left_id] = left_src_sibling;
+            // Tell the children (or primitives) of the moved left_src_sibling where it went.
+            self.relink_node(&left_src_sibling, dst_left_id);
 
             // If the to be removed node's parent was at the end of the array and has now moved update parent_id:
             if parent_id as u32 == src_left_id {
@@ -257,29 +223,20 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         let new_parent_id = best_sibling_candidate_id;
         self.nodes[new_parent_id] = new_parent;
 
-        if best_sibling_candidate.is_leaf() {
-            // Tell primitives where their node went.
-            update_primitives_to_nodes_for_node(
-                &best_sibling_candidate,
-                new_sibling_id as usize,
-                &self.primitive_indices,
-                &mut self.primitives_to_nodes,
-            )
-        } else {
-            // If the best selected sibling was an inner node, we need to update the parents mapping so that the children of
-            // that node point to the new location that it's being moved to.
-            self.parents[best_sibling_candidate.first_index as usize] = new_sibling_id;
-            self.parents[best_sibling_candidate.first_index as usize + 1] = new_sibling_id;
-
-            // The sibling was moved to the end of the node list, but its children stayed where they were,
-            // so they now come before their parent.
-            self.children_are_ordered_after_parents = false;
-        }
         self.nodes.push(best_sibling_candidate);
         let new_node_id = self.nodes.len();
         self.nodes.push(new_node); // Put the new node at the very end.
         self.parents.push(new_parent_id as u32);
         self.parents.push(new_parent_id as u32);
+
+        // Tell the children (or primitives) of the moved sibling where it went.
+        self.relink_node(&best_sibling_candidate, new_sibling_id as usize);
+
+        if !best_sibling_candidate.is_leaf() {
+            // The sibling was moved to the end of the node list, but its children stayed where they were,
+            // so they now come before their parent.
+            self.children_are_ordered_after_parents = false;
+        }
 
         // if primitives_to_nodes has already been initialized
         if !self.primitives_to_nodes.is_empty() {

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -478,9 +478,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// # Arguments
     /// * `node_id` - The index into `self.nodes` of the leaf being moved.
     /// * `aabb` - The new aabb of the leaf.
-    /// * `should_rotate` - Rotate on the refit walk, which keeps the BVH more balanced
-    ///   and can improve traversal speed at the cost of a slightly more expensive refit.
-    pub fn move_leaf(&mut self, node_id: usize, aabb: Aabb, should_rotate: bool) -> usize {
+    pub fn move_leaf(&mut self, node_id: usize, aabb: Aabb) -> usize {
         assert!(
             !self.uses_spatial_splits,
             "Moving leaves while using spatial splits is currently unsupported as it would require a mapping \
@@ -502,16 +500,11 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         let left_id = self.detach_leaf(node_id);
         let (sibling_id, sibling_depth) = self.find_sibling_greedy(node.aabb());
         let new_node_id = self.attach_leaf(node, sibling_id, left_id);
-        self.update_max_depth_for_greedy_insertion(sibling_depth, should_rotate);
+        self.update_max_depth_for_greedy_insertion(sibling_depth);
 
         // Need to work up the tree updating the aabbs since we just attached a node.
-        if should_rotate {
-            // A rotation along the way can move the node we just attached, so we track it.
-            self.refit_and_rotate_from_tracking(sibling_id, new_node_id)
-        } else {
-            self.refit_from_fast(sibling_id);
-            new_node_id
-        }
+        // A rotation along the way can move the node we just attached, so we track it.
+        self.refit_and_rotate_from_tracking_fast(sibling_id, new_node_id)
     }
 
     /// Moves the leaf that contains the given primitive to a new position in the BVH, resizing it to `aabb`.
@@ -524,9 +517,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// # Arguments
     /// * `aabb` - The new aabb of the primitive.
     /// * `primitive_id` - The index of the primitive being moved.
-    /// * `should_rotate` - Rotate on the refit walk, which keeps the BVH more balanced
-    ///   and can improve traversal speed at the cost of a slightly more expensive refit.
-    pub fn move_primitive(&mut self, aabb: Aabb, primitive_id: u32, should_rotate: bool) -> usize {
+    pub fn move_primitive(&mut self, aabb: Aabb, primitive_id: u32) -> usize {
         self.init_primitives_to_nodes_if_uninit();
         self.init_parents_if_uninit();
         let node_id = self.primitives_to_nodes[primitive_id as usize] as usize;
@@ -534,7 +525,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             self.nodes[node_id].prim_count, 1,
             "Bvh2::move_primitive() would move the other primitives in this leaf along with it."
         );
-        let new_node_id = self.move_leaf(node_id, aabb, should_rotate);
+        let new_node_id = self.move_leaf(node_id, aabb);
         debug_assert_eq!(
             self.primitives_to_nodes[primitive_id as usize],
             new_node_id as u32
@@ -543,20 +534,19 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     }
 
     /// Searches the tree with the greedy descent in [`Bvh2::find_sibling_greedy()`] to find a sibling
-    /// for the node being inserted, then attaches it there and refits back up to the root.
+    /// for the node being inserted, then attaches it there and refits back up to the root,
+    /// performing rotations along the way to keep the BVH from degenerating.
     ///
     /// This is the greedy counterpart of [`Bvh2::insert_leaf()`]. It doesn't need a traversal stack
     /// and it keeps [`Bvh2::max_depth`] up to date, at the cost of sometimes picking a slightly worse sibling.
     ///
     /// # Returns
-    /// The index of the newly added node. Note that with `should_rotate` this is generally not
-    /// `self.nodes.len() - 1`, since a rotation can move the node that was just attached.
+    /// The index of the newly added node. Note that this is generally not `self.nodes.len() - 1`,
+    /// since a rotation on the refit walk can move the node that was just attached.
     ///
     /// # Arguments
     /// * `new_node` - This node must be a leaf and already have a valid `first_index` into `primitive_indices`.
-    /// * `should_rotate` - Rotate on the refit walk, which keeps the BVH more balanced
-    ///   and can improve traversal speed at the cost of a slightly more expensive refit.
-    pub fn insert_leaf_greedy(&mut self, new_node: Bvh2Node, should_rotate: bool) -> usize {
+    pub fn insert_leaf_greedy(&mut self, new_node: Bvh2Node) -> usize {
         assert!(new_node.is_leaf());
 
         if self.nodes.is_empty() {
@@ -579,20 +569,16 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         self.parents.push(0);
 
         let new_node_id = self.attach_leaf(new_node, sibling_id, left_id);
-        self.update_max_depth_for_greedy_insertion(sibling_depth, should_rotate);
+        self.update_max_depth_for_greedy_insertion(sibling_depth);
 
         // Need to work up the tree updating the aabbs since we just added a node.
-        if should_rotate {
-            // A rotation along the way can move the node we just attached, so we track it.
-            self.refit_and_rotate_from_tracking(sibling_id, new_node_id)
-        } else {
-            self.refit_from_fast(sibling_id);
-            new_node_id
-        }
+        // A rotation along the way can move the node we just attached, so we track it.
+        self.refit_and_rotate_from_tracking_fast(sibling_id, new_node_id)
     }
 
     /// Searches the tree with the greedy descent in [`Bvh2::find_sibling_greedy()`] to find a sibling
-    /// for the primitive being inserted, then attaches it there and refits back up to the root.
+    /// for the primitive being inserted, then attaches it there and refits back up to the root,
+    /// performing rotations along the way to keep the BVH from degenerating.
     /// Updates [`Bvh2::primitive_indices`] and [`Bvh2::primitive_indices_freelist`].
     ///
     /// This is the greedy counterpart of [`Bvh2::insert_primitive()`]. It doesn't need a traversal stack
@@ -604,14 +590,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// # Arguments
     /// * `aabb` - The aabb of the primitive being inserted.
     /// * `primitive_id` - The index of the primitive being inserted.
-    /// * `should_rotate` - Rotate on the refit walk, which keeps the BVH more balanced
-    ///   and can improve traversal speed at the cost of a slightly more expensive refit.
-    pub fn insert_primitive_greedy(
-        &mut self,
-        aabb: Aabb,
-        primitive_id: u32,
-        should_rotate: bool,
-    ) -> usize {
+    pub fn insert_primitive_greedy(&mut self, aabb: Aabb, primitive_id: u32) -> usize {
         self.init_primitives_to_nodes_if_uninit();
         self.init_parents_if_uninit();
         if self.primitives_to_nodes.len() <= primitive_id as usize {
@@ -625,8 +604,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             self.primitive_indices.push(primitive_id);
             self.primitive_indices.len() as u32 - 1
         };
-        let new_node_id =
-            self.insert_leaf_greedy(Bvh2Node::new(aabb, 1, first_index), should_rotate);
+        let new_node_id = self.insert_leaf_greedy(Bvh2Node::new(aabb, 1, first_index));
         self.primitives_to_nodes[primitive_id as usize] = new_node_id as u32;
         new_node_id
     }
@@ -638,13 +616,11 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// its whole subtree is pushed one level deeper too, and the greedy descent never visits that subtree,
     /// so its height isn't known here.
     #[inline]
-    fn update_max_depth_for_greedy_insertion(&mut self, sibling_depth: usize, should_rotate: bool) {
+    fn update_max_depth_for_greedy_insertion(&mut self, sibling_depth: usize) {
         // + 1 for the new leaf below the sibling
         // + 1 because `max_depth` is a traversal stack size rather than a node depth
         // + 1 more for a rotation that may push the new leaf one level deeper
-        self.max_depth = self
-            .max_depth
-            .max(sibling_depth + 2 + should_rotate as usize);
+        self.max_depth = self.max_depth.max(sibling_depth + 3);
     }
 
     /// Computes the cost of a potential rotation around the node at `node_id`,
@@ -830,38 +806,84 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// Refit the BVH working up the tree from this node, ignoring leaves,
     /// performing rotations at each node along the way where beneficial.
     ///
+    /// Halts once two consecutive levels needed neither a resize nor a rotation.
+    /// Panics in debug if some parent still needed to be resized.
+    ///
     /// This can only be used to refit when a single node has changed or moved.
     ///
     /// See [`Bvh2::rotate_node()`] and [`Bvh2::refit_from()`].
-    pub fn refit_and_rotate_from(&mut self, index: usize) {
-        self.refit_and_rotate_from_tracking(index, INVALID as usize);
+    pub fn refit_and_rotate_from_fast(&mut self, index: usize) {
+        self.refit_and_rotate_from_tracking_fast(index, INVALID as usize);
     }
 
-    /// Same as [`Bvh2::refit_and_rotate_from()`], but follows the node at `tracked_node_id`
+    /// Same as [`Bvh2::refit_and_rotate_from_fast()`], but follows the node at `tracked_node_id`
     /// through any rotations applied along the way.
     ///
     /// # Returns
     /// The index that the tracked node ended up at.
-    fn refit_and_rotate_from_tracking(
+    fn refit_and_rotate_from_tracking_fast(
         &mut self,
         mut index: usize,
         mut tracked_node_id: usize,
     ) -> usize {
         self.init_parents_if_uninit();
+        let mut unchanged_count = 0;
+        #[cfg(debug_assertions)]
+        let mut stopped = false;
         loop {
             let node = self.nodes[index];
             if !node.is_leaf() {
                 let first_child_bbox = *self.nodes[node.first_index as usize].aabb();
                 let second_child_bbox = *self.nodes[node.first_index as usize + 1].aabb();
-                self.nodes[index].set_aabb(first_child_bbox.union(&second_child_bbox));
+                let new_aabb = first_child_bbox.union(&second_child_bbox);
+
+                let aabb_unchanged = self.nodes[index].aabb() == &new_aabb;
+
+                self.nodes[index].set_aabb(new_aabb);
+
+                #[cfg(debug_assertions)]
+                if stopped {
+                    // Debug builds keep going to check that nothing above actually needed refitting,
+                    // but it can't perform any more rotations so that `tracked_node_id` is stable.
+                    debug_assert!(
+                        aabb_unchanged,
+                        "Some parents still needed refitting. Unideal fitting is occurring somewhere."
+                    );
+                    if index == 0 {
+                        break;
+                    }
+                    index = self.parents[index] as usize;
+                    continue;
+                }
 
                 // A rotation only swaps nodes below `index`, so the computed aabb stays valid.
-                if let Some((from, to)) = self.rotate_node(index) {
+                let rotation = self.rotate_node(index);
+                if let Some((from, to)) = rotation {
                     if tracked_node_id == from {
                         tracked_node_id = to;
                     } else if tracked_node_id == to {
                         tracked_node_id = from;
                     }
+                }
+
+                // Two consecutive levels that didn't need a resize or a rotation mean that
+                // the ancestors above see no change in their children's or grandchildren's aabbs,
+                // which is what rotation candidates are based on, so we can stop early.
+                //
+                // Note that they could still have rotations that have not been evaluated,
+                // so this is a trade-off.
+                if aabb_unchanged && rotation.is_none() {
+                    unchanged_count += 1;
+                    if unchanged_count == 2 {
+                        #[cfg(not(debug_assertions))]
+                        return tracked_node_id;
+                        #[cfg(debug_assertions)]
+                        {
+                            stopped = true;
+                        }
+                    }
+                } else {
+                    unchanged_count = 0;
                 }
             }
             if index == 0 {
@@ -1003,14 +1025,14 @@ pub fn build_bvh2_by_insertion<T: Boundable>(primitives: &[T]) -> Bvh2 {
 /// Same as [`build_bvh2_by_insertion()`],  but with the greedy sibling search and rotations,
 /// just for testing insertion.
 ///
-/// Still slow at building compared to ploc, but uses a faster sibling search, and if `should_rotate` is true,
-/// doesn't degenerate into a deep BVH the way [`build_bvh2_by_insertion()`] can.
+/// Still slow at building compared to ploc, but uses a faster sibling search,
+/// and doesn't degenerate into a deep BVH the way [`build_bvh2_by_insertion()`] can.
 #[doc(hidden)]
-pub fn build_bvh2_by_greedy_insertion<T: Boundable>(primitives: &[T], should_rotate: bool) -> Bvh2 {
+pub fn build_bvh2_by_greedy_insertion<T: Boundable>(primitives: &[T]) -> Bvh2 {
     let mut bvh = Bvh2::default();
 
     for prim_id in 0..primitives.len() {
-        bvh.insert_primitive_greedy(primitives[prim_id].aabb(), prim_id as u32, should_rotate);
+        bvh.insert_primitive_greedy(primitives[prim_id].aabb(), prim_id as u32);
     }
 
     #[cfg(debug_assertions)]
@@ -1079,7 +1101,7 @@ mod tests {
     fn build_by_greedy_insertion() {
         for res in 30..=32 {
             let tris = demoscene(res, 0);
-            let bvh = build_bvh2_by_greedy_insertion(&tris, true);
+            let bvh = build_bvh2_by_greedy_insertion(&tris);
             bvh.validate(&tris, false, true);
         }
     }
@@ -1250,7 +1272,7 @@ mod tests {
         // The greedy descent knows the depth of the sibling it picked, so insertion can keep `max_depth` up to date.
         // Bvh2::validate() requires it to be a valid stack size, so a stale `max_depth` would fail the validation below.
         let tris = demoscene(32, 0);
-        let bvh = build_bvh2_by_greedy_insertion(&tris, true);
+        let bvh = build_bvh2_by_greedy_insertion(&tris);
 
         assert!(
             bvh.depth(0) <= bvh.max_depth,
@@ -1262,48 +1284,6 @@ mod tests {
     }
 
     #[test]
-    fn greedy_insertion_without_rotations() {
-        let tris = demoscene(24, 0);
-
-        let mut bvh = Bvh2::default();
-        for (prim_id, tri) in tris.iter().enumerate() {
-            let node_id = bvh.insert_primitive_greedy(tri.aabb(), prim_id as u32, false);
-            if prim_id > 0 {
-                assert_eq!(node_id, bvh.nodes.len() - 1);
-            }
-            assert_eq!(bvh.primitives_to_nodes[prim_id], node_id as u32);
-        }
-        bvh.validate(&tris, false, true);
-
-        // Moving without rotations reuses the freed pair, so the node count still doesn't change.
-        let node_count = bvh.nodes.len();
-        for (prim_id, tri) in tris.iter().enumerate() {
-            let mut aabb = tri.aabb();
-            aabb.min -= 0.05;
-            aabb.max += 0.05;
-            let node_id = bvh.move_primitive(aabb, prim_id as u32, false);
-            assert_eq!(bvh.nodes.len(), node_count);
-            assert_eq!(bvh.primitives_to_nodes[prim_id], node_id as u32);
-        }
-        bvh.validate_parents();
-        bvh.validate_primitives_to_nodes();
-
-        // The rotation-free tree should be deeper than the rotated one for the same input.
-        let rotated = build_bvh2_by_greedy_insertion(&tris, true);
-        let unrotated = build_bvh2_by_greedy_insertion(&tris, false);
-        assert!(
-            rotated.depth(0) < unrotated.depth(0),
-            "rotations should produce a shallower bvh: {} vs {}",
-            rotated.depth(0),
-            unrotated.depth(0)
-        );
-
-        // `max_depth` should stay a valid stack size either way.
-        assert!(rotated.depth(0) <= rotated.max_depth);
-        assert!(unrotated.depth(0) <= unrotated.max_depth);
-    }
-
-    #[test]
     fn rotations_prevent_degenerate_bvh() {
         // With plain insertion, sorted input degenerates the BVH into a list.
         // Greedy insertion rotates on the refit walk, which recovers the quality incrementally.
@@ -1311,7 +1291,7 @@ mod tests {
 
         let mut with_rotations = Bvh2::default();
         for (prim_id, aabb) in boxes.iter().enumerate() {
-            with_rotations.insert_primitive_greedy(*aabb, prim_id as u32, true);
+            with_rotations.insert_primitive_greedy(*aabb, prim_id as u32);
         }
         with_rotations.validate(&boxes, false, true);
 
@@ -1377,13 +1357,13 @@ mod tests {
             let mut aabb = tris[primitive_id as usize].aabb();
             aabb.min -= 0.05;
             aabb.max += 0.05;
-            bvh.move_primitive(aabb, primitive_id, true);
+            bvh.move_primitive(aabb, primitive_id);
             assert_eq!(bvh.nodes.len(), node_count);
             bvh.validate_parents();
             bvh.validate_primitives_to_nodes();
         }
         for primitive_id in 0..tris.len() as u32 {
-            bvh.move_primitive(tris[primitive_id as usize].aabb(), primitive_id, true);
+            bvh.move_primitive(tris[primitive_id as usize].aabb(), primitive_id);
             assert_eq!(bvh.nodes.len(), node_count);
         }
 
@@ -1396,17 +1376,17 @@ mod tests {
         let tris = demoscene(16, 0);
 
         let mut bvh = Bvh2::default();
-        bvh.insert_primitive_greedy(tris[0].aabb(), 0, true);
+        bvh.insert_primitive_greedy(tris[0].aabb(), 0);
         assert_eq!(bvh.nodes.len(), 1);
 
         let mut aabb = tris[0].aabb();
         aabb.max += 1.0;
-        assert_eq!(bvh.move_leaf(0, aabb, true), 0);
+        assert_eq!(bvh.move_leaf(0, aabb), 0);
         assert_eq!(bvh.nodes.len(), 1);
         assert_eq!(*bvh.nodes[0].aabb(), aabb);
 
-        bvh.insert_primitive_greedy(tris[1].aabb(), 1, true);
-        bvh.move_primitive(tris[0].aabb(), 0, true);
+        bvh.insert_primitive_greedy(tris[1].aabb(), 1);
+        bvh.move_primitive(tris[0].aabb(), 0);
         bvh.validate(&tris[0..2], false, true);
     }
 }

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -317,10 +317,12 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
 
             inherited_cost += direct_cost - area_base;
 
-            let left_is_leaf = self.nodes[left_id].is_leaf();
-            let right_is_leaf = self.nodes[right_id].is_leaf();
-            let left_aabb = *self.nodes[left_id].aabb();
-            let right_aabb = *self.nodes[right_id].aabb();
+            let left = &self.nodes[left_id];
+            let right = &self.nodes[right_id];
+            let left_is_leaf = left.is_leaf();
+            let right_is_leaf = right.is_leaf();
+            let left_aabb = left.aabb();
+            let right_aabb = right.aabb();
             let left_direct_cost = left_aabb.union(aabb).half_area();
             let right_direct_cost = right_aabb.union(aabb).half_area();
 

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -504,7 +504,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         let new_node_id = self.attach_leaf(node, sibling_id, left_id);
         self.update_max_depth_for_greedy_insertion(sibling_depth, should_rotate);
 
-        // Need to work up the tree updating the aabbs since we just added a node.
+        // Need to work up the tree updating the aabbs since we just attached a node.
         if should_rotate {
             // A rotation along the way can move the node we just attached, so we track it.
             self.refit_and_rotate_from_tracking(sibling_id, new_node_id)

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -1325,7 +1325,7 @@ mod tests {
         let unrotated_depth = without_rotations.depth(0);
 
         // This is 11 vs 513 at the time of writing, but for the test,
-        // pinning exact numbers probably isn't worthwile.
+        // pinning exact numbers probably isn't worthwhile.
         assert!(
             rotated_depth * 45 < unrotated_depth,
             "rotations should keep the bvh far shallower: {rotated_depth} vs {unrotated_depth}"

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -471,7 +471,6 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// This is the fused equivalent of [`Bvh2::remove_leaf()`] followed by [`Bvh2::insert_leaf_greedy()`].
     ///
     /// `Bvh2::nodes.len()` is unchanged across the call and `Bvh2::primitive_indices` is untouched.
-    /// Uses the greedy sibling search ([`Bvh2::find_sibling_greedy()`]) and rotates on the refit walk ([`Bvh2::refit_and_rotate_from()`]).
     ///
     /// # Returns
     /// The index of the moved node.
@@ -479,7 +478,9 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// # Arguments
     /// * `node_id` - The index into `self.nodes` of the leaf being moved.
     /// * `aabb` - The new aabb of the leaf.
-    pub fn move_leaf(&mut self, node_id: usize, aabb: Aabb) -> usize {
+    /// * `should_rotate` - Rotate on the refit walk, which keeps the BVH more balanced
+    ///   and can improve traversal speed at the cost of a slightly more expensive refit.
+    pub fn move_leaf(&mut self, node_id: usize, aabb: Aabb, should_rotate: bool) -> usize {
         assert!(
             !self.uses_spatial_splits,
             "Moving leaves while using spatial splits is currently unsupported as it would require a mapping \
@@ -501,11 +502,16 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         let left_id = self.detach_leaf(node_id);
         let (sibling_id, sibling_depth) = self.find_sibling_greedy(node.aabb());
         let new_node_id = self.attach_leaf(node, sibling_id, left_id);
-        self.update_max_depth_for_greedy_insertion(sibling_depth);
+        self.update_max_depth_for_greedy_insertion(sibling_depth, should_rotate);
 
         // Need to work up the tree updating the aabbs since we just added a node.
-        // A rotation along the way can move the node we just attached, so we track it.
-        self.refit_and_rotate_from_tracking(sibling_id, new_node_id)
+        if should_rotate {
+            // A rotation along the way can move the node we just attached, so we track it.
+            self.refit_and_rotate_from_tracking(sibling_id, new_node_id)
+        } else {
+            self.refit_from_fast(sibling_id);
+            new_node_id
+        }
     }
 
     /// Moves the leaf that contains the given primitive to a new position in the BVH, resizing it to `aabb`.
@@ -518,7 +524,9 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// # Arguments
     /// * `aabb` - The new aabb of the primitive.
     /// * `primitive_id` - The index of the primitive being moved.
-    pub fn move_primitive(&mut self, aabb: Aabb, primitive_id: u32) -> usize {
+    /// * `should_rotate` - Rotate on the refit walk, which keeps the BVH more balanced
+    ///   and can improve traversal speed at the cost of a slightly more expensive refit.
+    pub fn move_primitive(&mut self, aabb: Aabb, primitive_id: u32, should_rotate: bool) -> usize {
         self.init_primitives_to_nodes_if_uninit();
         self.init_parents_if_uninit();
         let node_id = self.primitives_to_nodes[primitive_id as usize] as usize;
@@ -526,7 +534,7 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             self.nodes[node_id].prim_count, 1,
             "Bvh2::move_primitive() would move the other primitives in this leaf along with it."
         );
-        let new_node_id = self.move_leaf(node_id, aabb);
+        let new_node_id = self.move_leaf(node_id, aabb, should_rotate);
         debug_assert_eq!(
             self.primitives_to_nodes[primitive_id as usize],
             new_node_id as u32
@@ -535,18 +543,20 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     }
 
     /// Searches the tree with the greedy descent in [`Bvh2::find_sibling_greedy()`] to find a sibling
-    /// for the node being inserted, then attaches it there and rotates on the refit walk back up to the root.
+    /// for the node being inserted, then attaches it there and refits back up to the root.
     ///
-    /// This is the greedy counterpart of [`Bvh2::insert_leaf()`]. It doesn't need a traversal stack,
-    /// it keeps [`Bvh2::max_depth`] up to date, and it keeps the BVH from degenerating as leaves are inserted,
-    /// at the cost of sometimes picking a slightly worse sibling.
+    /// This is the greedy counterpart of [`Bvh2::insert_leaf()`]. It doesn't need a traversal stack
+    /// and it keeps [`Bvh2::max_depth`] up to date, at the cost of sometimes picking a slightly worse sibling.
     ///
     /// # Returns
-    /// The index of the newly added node.
+    /// The index of the newly added node. Note that with `should_rotate` this is generally not
+    /// `self.nodes.len() - 1`, since a rotation can move the node that was just attached.
     ///
     /// # Arguments
     /// * `new_node` - This node must be a leaf and already have a valid `first_index` into `primitive_indices`.
-    pub fn insert_leaf_greedy(&mut self, new_node: Bvh2Node) -> usize {
+    /// * `should_rotate` - Rotate on the refit walk, which keeps the BVH more balanced
+    ///   and can improve traversal speed at the cost of a slightly more expensive refit.
+    pub fn insert_leaf_greedy(&mut self, new_node: Bvh2Node, should_rotate: bool) -> usize {
         assert!(new_node.is_leaf());
 
         if self.nodes.is_empty() {
@@ -569,20 +579,24 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         self.parents.push(0);
 
         let new_node_id = self.attach_leaf(new_node, sibling_id, left_id);
-        self.update_max_depth_for_greedy_insertion(sibling_depth);
+        self.update_max_depth_for_greedy_insertion(sibling_depth, should_rotate);
 
         // Need to work up the tree updating the aabbs since we just added a node.
-        // A rotation along the way can move the node we just attached, so we track it.
-        self.refit_and_rotate_from_tracking(sibling_id, new_node_id)
+        if should_rotate {
+            // A rotation along the way can move the node we just attached, so we track it.
+            self.refit_and_rotate_from_tracking(sibling_id, new_node_id)
+        } else {
+            self.refit_from_fast(sibling_id);
+            new_node_id
+        }
     }
 
     /// Searches the tree with the greedy descent in [`Bvh2::find_sibling_greedy()`] to find a sibling
-    /// for the primitive being inserted, then attaches it there and rotates on the refit walk back up to the root.
+    /// for the primitive being inserted, then attaches it there and refits back up to the root.
     /// Updates [`Bvh2::primitive_indices`] and [`Bvh2::primitive_indices_freelist`].
     ///
-    /// This is the greedy counterpart of [`Bvh2::insert_primitive()`]. It doesn't need a traversal stack,
-    /// it keeps [`Bvh2::max_depth`] up to date, and it keeps the BVH from degenerating as leaves are inserted,
-    /// at the cost of sometimes picking a slightly worse sibling.
+    /// This is the greedy counterpart of [`Bvh2::insert_primitive()`]. It doesn't need a traversal stack
+    /// and it keeps [`Bvh2::max_depth`] up to date, at the cost of sometimes picking a slightly worse sibling.
     ///
     /// # Returns
     /// The index of the newly added node.
@@ -590,7 +604,14 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// # Arguments
     /// * `aabb` - The aabb of the primitive being inserted.
     /// * `primitive_id` - The index of the primitive being inserted.
-    pub fn insert_primitive_greedy(&mut self, aabb: Aabb, primitive_id: u32) -> usize {
+    /// * `should_rotate` - Rotate on the refit walk, which keeps the BVH more balanced
+    ///   and can improve traversal speed at the cost of a slightly more expensive refit.
+    pub fn insert_primitive_greedy(
+        &mut self,
+        aabb: Aabb,
+        primitive_id: u32,
+        should_rotate: bool,
+    ) -> usize {
         self.init_primitives_to_nodes_if_uninit();
         self.init_parents_if_uninit();
         if self.primitives_to_nodes.len() <= primitive_id as usize {
@@ -604,7 +625,8 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             self.primitive_indices.push(primitive_id);
             self.primitive_indices.len() as u32 - 1
         };
-        let new_node_id = self.insert_leaf_greedy(Bvh2Node::new(aabb, 1, first_index));
+        let new_node_id =
+            self.insert_leaf_greedy(Bvh2Node::new(aabb, 1, first_index), should_rotate);
         self.primitives_to_nodes[primitive_id as usize] = new_node_id as u32;
         new_node_id
     }
@@ -616,11 +638,13 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
     /// its whole subtree is pushed one level deeper too, and the greedy descent never visits that subtree,
     /// so its height isn't known here.
     #[inline]
-    fn update_max_depth_for_greedy_insertion(&mut self, sibling_depth: usize) {
+    fn update_max_depth_for_greedy_insertion(&mut self, sibling_depth: usize, should_rotate: bool) {
         // + 1 for the new leaf below the sibling
-        // + 1 for a rotation that may push it one level deeper
         // + 1 because `max_depth` is a traversal stack size rather than a node depth
-        self.max_depth = self.max_depth.max(sibling_depth + 3);
+        // + 1 more for a rotation that may push the new leaf one level deeper
+        self.max_depth = self
+            .max_depth
+            .max(sibling_depth + 2 + should_rotate as usize);
     }
 
     /// Considers swapping one of the children of the node at `node_id` with one of the other child's children,
@@ -936,14 +960,14 @@ pub fn build_bvh2_by_insertion<T: Boundable>(primitives: &[T]) -> Bvh2 {
 /// Same as [`build_bvh2_by_insertion()`],  but with the greedy sibling search and rotations,
 /// just for testing insertion.
 ///
-/// Still slow at building compared to ploc, but uses a faster sibling search, and doesn't degenerate
-/// the way plain insertion does.
+/// Still slow at building compared to ploc, but uses a faster sibling search, and if `should_rotate` is true,
+/// doesn't degenerate into a deep BVH the way [`build_bvh2_by_insertion()`] can.
 #[doc(hidden)]
-pub fn build_bvh2_by_greedy_insertion<T: Boundable>(primitives: &[T]) -> Bvh2 {
+pub fn build_bvh2_by_greedy_insertion<T: Boundable>(primitives: &[T], should_rotate: bool) -> Bvh2 {
     let mut bvh = Bvh2::default();
 
     for prim_id in 0..primitives.len() {
-        bvh.insert_primitive_greedy(primitives[prim_id].aabb(), prim_id as u32);
+        bvh.insert_primitive_greedy(primitives[prim_id].aabb(), prim_id as u32, should_rotate);
     }
 
     #[cfg(debug_assertions)]
@@ -1012,7 +1036,7 @@ mod tests {
     fn build_by_greedy_insertion() {
         for res in 30..=32 {
             let tris = demoscene(res, 0);
-            let bvh = build_bvh2_by_greedy_insertion(&tris);
+            let bvh = build_bvh2_by_greedy_insertion(&tris, true);
             bvh.validate(&tris, false, true);
         }
     }
@@ -1183,7 +1207,7 @@ mod tests {
         // The greedy descent knows the depth of the sibling it picked, so insertion can keep `max_depth` up to date.
         // Bvh2::validate() requires it to be a valid stack size, so a stale `max_depth` would fail the validation below.
         let tris = demoscene(32, 0);
-        let bvh = build_bvh2_by_greedy_insertion(&tris);
+        let bvh = build_bvh2_by_greedy_insertion(&tris, true);
 
         assert!(
             bvh.depth(0) <= bvh.max_depth,
@@ -1195,6 +1219,48 @@ mod tests {
     }
 
     #[test]
+    fn greedy_insertion_without_rotations() {
+        let tris = demoscene(24, 0);
+
+        let mut bvh = Bvh2::default();
+        for (prim_id, tri) in tris.iter().enumerate() {
+            let node_id = bvh.insert_primitive_greedy(tri.aabb(), prim_id as u32, false);
+            if prim_id > 0 {
+                assert_eq!(node_id, bvh.nodes.len() - 1);
+            }
+            assert_eq!(bvh.primitives_to_nodes[prim_id], node_id as u32);
+        }
+        bvh.validate(&tris, false, true);
+
+        // Moving without rotations reuses the freed pair, so the node count still doesn't change.
+        let node_count = bvh.nodes.len();
+        for (prim_id, tri) in tris.iter().enumerate() {
+            let mut aabb = tri.aabb();
+            aabb.min -= 0.05;
+            aabb.max += 0.05;
+            let node_id = bvh.move_primitive(aabb, prim_id as u32, false);
+            assert_eq!(bvh.nodes.len(), node_count);
+            assert_eq!(bvh.primitives_to_nodes[prim_id], node_id as u32);
+        }
+        bvh.validate_parents();
+        bvh.validate_primitives_to_nodes();
+
+        // The rotation-free tree should be deeper than the rotated one for the same input.
+        let rotated = build_bvh2_by_greedy_insertion(&tris, true);
+        let unrotated = build_bvh2_by_greedy_insertion(&tris, false);
+        assert!(
+            rotated.depth(0) < unrotated.depth(0),
+            "rotations should produce a shallower bvh: {} vs {}",
+            rotated.depth(0),
+            unrotated.depth(0)
+        );
+
+        // `max_depth` should stay a valid stack size either way.
+        assert!(rotated.depth(0) <= rotated.max_depth);
+        assert!(unrotated.depth(0) <= unrotated.max_depth);
+    }
+
+    #[test]
     fn rotations_prevent_degenerate_bvh() {
         // With plain insertion, sorted input degenerates the BVH into a list.
         // Greedy insertion rotates on the refit walk, which recovers the quality incrementally.
@@ -1202,7 +1268,7 @@ mod tests {
 
         let mut with_rotations = Bvh2::default();
         for (prim_id, aabb) in boxes.iter().enumerate() {
-            with_rotations.insert_primitive_greedy(*aabb, prim_id as u32);
+            with_rotations.insert_primitive_greedy(*aabb, prim_id as u32, true);
         }
         with_rotations.validate(&boxes, false, true);
 
@@ -1268,13 +1334,13 @@ mod tests {
             let mut aabb = tris[primitive_id as usize].aabb();
             aabb.min -= 0.05;
             aabb.max += 0.05;
-            bvh.move_primitive(aabb, primitive_id);
+            bvh.move_primitive(aabb, primitive_id, true);
             assert_eq!(bvh.nodes.len(), node_count);
             bvh.validate_parents();
             bvh.validate_primitives_to_nodes();
         }
         for primitive_id in 0..tris.len() as u32 {
-            bvh.move_primitive(tris[primitive_id as usize].aabb(), primitive_id);
+            bvh.move_primitive(tris[primitive_id as usize].aabb(), primitive_id, true);
             assert_eq!(bvh.nodes.len(), node_count);
         }
 
@@ -1287,17 +1353,17 @@ mod tests {
         let tris = demoscene(16, 0);
 
         let mut bvh = Bvh2::default();
-        bvh.insert_primitive_greedy(tris[0].aabb(), 0);
+        bvh.insert_primitive_greedy(tris[0].aabb(), 0, true);
         assert_eq!(bvh.nodes.len(), 1);
 
         let mut aabb = tris[0].aabb();
         aabb.max += 1.0;
-        assert_eq!(bvh.move_leaf(0, aabb), 0);
+        assert_eq!(bvh.move_leaf(0, aabb, true), 0);
         assert_eq!(bvh.nodes.len(), 1);
         assert_eq!(*bvh.nodes[0].aabb(), aabb);
 
-        bvh.insert_primitive_greedy(tris[1].aabb(), 1);
-        bvh.move_primitive(tris[0].aabb(), 0);
+        bvh.insert_primitive_greedy(tris[1].aabb(), 1, true);
+        bvh.move_primitive(tris[0].aabb(), 0, true);
         bvh.validate(&tris[0..2], false, true);
     }
 }

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -693,6 +693,8 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
         let c_area = c.aabb().half_area();
         let mut best_cost = b_area + c_area;
 
+        /// The two slots to swap, the node that ends up with a different pair of children,
+        /// and the aabb it ends up with.
         struct RotationCandidate {
             from: usize,
             to: usize,
@@ -700,7 +702,6 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
             refit_aabb: Aabb,
         }
 
-        // The two slots to swap, the node that ends up with a different pair of children, and the aabb it ends up with.
         let mut best_rotation: Option<RotationCandidate> = None;
 
         if !c.is_leaf() {

--- a/src/bvh2/insertion_removal.rs
+++ b/src/bvh2/insertion_removal.rs
@@ -367,6 +367,9 @@ from one primitive to multiple nodes in `Bvh2::primitives_to_nodes`."
                     inherited_cost + right_direct_cost + (area - right_area).min(0.0);
             }
 
+            // Note: Box2D also has a separate early out if both children are leaves,
+            //       but because the costs for leaves are left as f32::MAX, this check
+            //       handles that too.
             if best_cost <= left_lower_cost && best_cost <= right_lower_cost {
                 // Neither subtree can beat the best candidate already found.
                 break;

--- a/src/bvh2/mod.rs
+++ b/src/bvh2/mod.rs
@@ -750,6 +750,39 @@ impl Bvh2 {
         }
     }
 
+    /// Tell the children of the node at `node_id`, or the primitives it contains if it is a leaf,
+    /// that it is now at `node_id`. Needed after moving a node into a different slot in `Bvh2::nodes`.
+    ///
+    /// If the node is already available, prefer [`Bvh2::relink_node()`].
+    #[inline]
+    pub fn relink(&mut self, node_id: usize) {
+        let node = self.nodes[node_id];
+        self.relink_node(&node, node_id);
+    }
+
+    /// Tell the children of `node`, or the primitives it contains if it is a leaf,
+    /// that it is now at `node_id`. Needed after moving a node into a different slot in `Bvh2::nodes`.
+    ///
+    /// `node` must be the node that now occupies the `node_id` slot of `Bvh2::nodes`.
+    #[inline]
+    pub fn relink_node(&mut self, node: &Bvh2Node, node_id: usize) {
+        debug_assert_eq!(node.first_index, self.nodes[node_id].first_index);
+        debug_assert_eq!(node.prim_count, self.nodes[node_id].prim_count);
+        if node.is_leaf() {
+            // Tell primitives where their node went.
+            update_primitives_to_nodes_for_node(
+                node,
+                node_id,
+                &self.primitive_indices,
+                &mut self.primitives_to_nodes,
+            )
+        } else {
+            // Tell children where their parent went.
+            self.parents[node.first_index as usize] = node_id as u32;
+            self.parents[node.first_index as usize + 1] = node_id as u32;
+        }
+    }
+
     /// Update node aabb and refit the BVH working up the tree from this node.
     #[inline]
     pub fn resize_node(&mut self, node_id: usize, aabb: Aabb) {

--- a/src/bvh2/reinsertion.rs
+++ b/src/bvh2/reinsertion.rs
@@ -19,8 +19,6 @@ use crate::{
     faststack::FastStack,
 };
 
-use super::update_primitives_to_nodes_for_node;
-
 /// Restructures the BVH, optimizing node locations within the BVH hierarchy per SAH cost.
 #[derive(Default)]
 pub struct ReinsertionOptimizer {
@@ -347,33 +345,9 @@ pub fn reinsert_node(bvh: &mut Bvh2, from: usize, to: usize) {
     bvh.nodes[sibling_id] = dst_node;
     bvh.nodes[parent_id] = sibling_node;
 
-    let sibling_node = &bvh.nodes[sibling_id];
-    if sibling_node.is_leaf() {
-        // Tell primitives where their node went.
-        update_primitives_to_nodes_for_node(
-            sibling_node,
-            sibling_id,
-            &bvh.primitive_indices,
-            &mut bvh.primitives_to_nodes,
-        );
-    } else {
-        bvh.parents[sibling_node.first_index as usize] = sibling_id as u32;
-        bvh.parents[sibling_node.first_index as usize + 1] = sibling_id as u32;
-    }
-
-    let parent_node = &bvh.nodes[parent_id];
-    if bvh.nodes[parent_id].is_leaf() {
-        // Tell primitives where their node went.
-        update_primitives_to_nodes_for_node(
-            parent_node,
-            parent_id,
-            &bvh.primitive_indices,
-            &mut bvh.primitives_to_nodes,
-        );
-    } else {
-        bvh.parents[parent_node.first_index as usize] = parent_id as u32;
-        bvh.parents[parent_node.first_index as usize + 1] = parent_id as u32;
-    }
+    // Tell the children (or primitives) of the two moved nodes where they went.
+    bvh.relink_node(&dst_node, sibling_id);
+    bvh.relink_node(&sibling_node, parent_id);
 
     bvh.parents[sibling_id] = to as u32;
     bvh.parents[from] = to as u32;


### PR DESCRIPTION
# Objective

Currently, `insert` uses the "branch and bound" algorithm, which finds the optimal sibling for insertion, but is fairly slow. It also does nothing to prevent the tree from degenerating over successive insertions, which can lead to extremely deep trees.

In practice, Box2D and Box3D use a cheaper insertion algorithm that just follows a single path greedily ([link](https://github.com/erincatto/box2d/blob/617d32ab02570930625bbcb8479f54be9bf8d045/src/dynamic_tree.c#L164)), and therefore scales as O(depth). Additionally, it incrementally performs rotations ([link](https://github.com/erincatto/box2d/blob/617d32ab02570930625bbcb8479f54be9bf8d045/src/dynamic_tree.c#L315)) on the tree along the refit walk when inserting new broad phase proxies (=BVH primitives). This keeps the BVH from degenerating into a deep tree for fairly minimal cost, which in turn makes insertion even faster.

## Solution

Add the following for `Bvh2`:

- `find_sibling_greedy`, which is based on `b2FindBestSibling` in Box2D
- `rotate_node`, which is based on `b2RotateNodes` in Box2D
- `insert_leaf_greedy` and `insert_primitive_greedy` as faster, greedy alternatives to the branch-and-bound versions
- `move_leaf` and `move_primitive` as a faster, fused "remove and insert back" method that skips some extra work that doing them separately requires
- `refit_and_rotate_from_fast` as a version of `refit_from_fast` that performs tree rotations along the walk
- Some helpers

I also added `relink` and `relink_node` to get rid of some pretty heavy duplication, since this PR would've added even more copies of the exact same logic.

## Performance

### Building trees from scratch

(this is relevant for bulk-spawning colliders in a physics engine)

In my rough measurements, for building a 50k primitive tree from scratch, greedy insertion with rotation is ~3.5x as fast as the branch-and-bound algorithm, has more than 3x better SAH, and results in over 2x traversal speed. Notably, the rotations also allow it to scale much better with large trees, because it keeps tree depth pretty minimal, which in itself makes insertion faster as well.

### Inserting into an existing tree

(this is relevant for spawning colliders here and there at runtime, or teleporting them around)

With a 50k triangle `medium_build` tree, inserting 1,000 primitives is ~2.3x as fast using greedy insertion with rotation, with depth and SAH being near-identical compared to the original tree, while the other configurations degrade with larger insertion batches.

## Do we need the old insertion algorithm?

The existing insertion algo seems to be worse across the board in practice. One way to alleviate this is to also add rotations for it (I didn't do this yet, since it'd be a breaking change). I tried this, and it does help, but it still loses on build/insertion perf by more than 2x.

So, for my own purposes, the existing insertion algorithm isn't too useful, and I plan on just using the greedy version everywhere, especially since I run an optimization task on the tree anyway to keep quality high. There are some other differences too that I've documented on the methods, but personally I'd be fine just yeeting the method, which would also reduce the API surface a bit and give the nicer name (no `_greedy` suffix) to the generally better method. It is a breaking change though, so I'll wait for comments on this :)

## Further context

I originally implemented the greedy algo for Avian in https://github.com/avianphysics/avian/pull/1049, but that was without rotation. For the OBVHS version in this PR, I refactored things slightly and added more docs and tests, as well as all of the other stuff. I haven't measured the total effect in Avian yet, the numbers here were profiled separately.